### PR TITLE
TASK-2: Xcode プロジェクト雛形を xcodegen で生成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,8 @@ fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
 
-# xcodegen 生成物 (project.yml から再生成可能なため追跡しない方針に倒す場合はコメント解除)
-# *.xcodeproj
+# xcodegen 生成物 (project.yml から再生成する方針。Clone 後は `make -C ios generate`)
+*.xcodeproj
 
 # Environment variables
 .env

--- a/ios/DailyLog/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/DailyLog/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/DailyLog/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/DailyLog/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/DailyLog/Assets.xcassets/Contents.json
+++ b/ios/DailyLog/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/DailyLog/ContentView.swift
+++ b/ios/DailyLog/ContentView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "clock.arrow.circlepath")
+                .font(.system(size: 48))
+                .foregroundStyle(.tint)
+            Text("DailyLog")
+                .font(.title)
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/ios/DailyLog/DailyLog.entitlements
+++ b/ios/DailyLog/DailyLog.entitlements
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.coco.daily-log</string>
+    </array>
+    <key>com.apple.developer.icloud-container-identifiers</key>
+    <array>
+        <string>iCloud.com.coco.daily-log</string>
+    </array>
+    <key>com.apple.developer.icloud-services</key>
+    <array>
+        <string>CloudKit</string>
+    </array>
+    <key>com.apple.developer.ubiquity-kvstore-identifier</key>
+    <string>$(TeamIdentifierPrefix)com.coco.daily-log</string>
+</dict>
+</plist>

--- a/ios/DailyLog/DailyLogApp.swift
+++ b/ios/DailyLog/DailyLogApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct DailyLogApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ios/DailyLogTests/DailyLogTests.swift
+++ b/ios/DailyLogTests/DailyLogTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import DailyLog
+
+final class DailyLogTests: XCTestCase {
+    func testPlaceholder() {
+        XCTAssertTrue(true)
+    }
+}

--- a/ios/DailyLogWidget/DailyLogWidget.entitlements
+++ b/ios/DailyLogWidget/DailyLogWidget.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.coco.daily-log</string>
+    </array>
+</dict>
+</plist>

--- a/ios/DailyLogWidget/DailyLogWidget.swift
+++ b/ios/DailyLogWidget/DailyLogWidget.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+import WidgetKit
+
+struct DailyLogWidget: Widget {
+    let kind: String = "DailyLogWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: DailyLogTimelineProvider()) { entry in
+            DailyLogWidgetEntryView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("DailyLog")
+        .description("進行中の行動を表示します")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+struct DailyLogEntry: TimelineEntry {
+    let date: Date
+}
+
+struct DailyLogTimelineProvider: TimelineProvider {
+    func placeholder(in context: Context) -> DailyLogEntry {
+        DailyLogEntry(date: Date())
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (DailyLogEntry) -> Void) {
+        completion(DailyLogEntry(date: Date()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<DailyLogEntry>) -> Void) {
+        let timeline = Timeline(entries: [DailyLogEntry(date: Date())], policy: .atEnd)
+        completion(timeline)
+    }
+}
+
+struct DailyLogWidgetEntryView: View {
+    let entry: DailyLogEntry
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("DailyLog")
+                .font(.headline)
+            Text(entry.date, style: .time)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/ios/DailyLogWidget/DailyLogWidgetBundle.swift
+++ b/ios/DailyLogWidget/DailyLogWidgetBundle.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct DailyLogWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        DailyLogWidget()
+    }
+}

--- a/ios/DailyLogWidget/Info.plist
+++ b/ios/DailyLogWidget/Info.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>DailyLogWidget</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key>
+    <string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.widgetkit-extension</string>
+    </dict>
+</dict>
+</plist>

--- a/ios/Makefile
+++ b/ios/Makefile
@@ -1,0 +1,40 @@
+.PHONY: generate build test lint format clean
+
+PROJECT := DailyLog.xcodeproj
+SCHEME := DailyLog
+DESTINATION := platform=iOS Simulator,name=iPhone 17,OS=latest
+
+generate:
+	xcodegen generate
+
+build: generate
+	xcodebuild \
+		-project $(PROJECT) \
+		-scheme $(SCHEME) \
+		-destination '$(DESTINATION)' \
+		-configuration Debug \
+		build | xcbeautify || xcodebuild \
+		-project $(PROJECT) \
+		-scheme $(SCHEME) \
+		-destination '$(DESTINATION)' \
+		-configuration Debug \
+		build
+
+test: generate
+	xcodebuild \
+		-project $(PROJECT) \
+		-scheme $(SCHEME) \
+		-destination '$(DESTINATION)' \
+		test
+
+lint:
+	cd .. && swiftlint --config .swiftlint.yml ios
+
+format-check:
+	cd .. && swiftformat --lint --config .swiftformat ios
+
+format:
+	cd .. && swiftformat --config .swiftformat ios
+
+clean:
+	rm -rf $(PROJECT) build DerivedData

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -1,0 +1,82 @@
+name: DailyLog
+options:
+  bundleIdPrefix: com.coco
+  deploymentTarget:
+    iOS: "17.0"
+  createIntermediateGroups: true
+  generateEmptyDirectories: true
+  xcodeVersion: "15.0"
+settings:
+  base:
+    SWIFT_VERSION: "5.9"
+    IPHONEOS_DEPLOYMENT_TARGET: "17.0"
+    MARKETING_VERSION: "0.1.0"
+    CURRENT_PROJECT_VERSION: "1"
+    CODE_SIGN_STYLE: Automatic
+    DEVELOPMENT_TEAM: ""
+    ENABLE_USER_SCRIPT_SANDBOXING: YES
+    SWIFT_STRICT_CONCURRENCY: complete
+
+targets:
+  DailyLog:
+    type: application
+    platform: iOS
+    sources:
+      - path: DailyLog
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.coco.daily-log
+        PRODUCT_NAME: DailyLog
+        CODE_SIGN_ENTITLEMENTS: DailyLog/DailyLog.entitlements
+        GENERATE_INFOPLIST_FILE: YES
+        INFOPLIST_KEY_CFBundleDisplayName: DailyLog
+        INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: "UIInterfaceOrientationPortrait"
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
+        INFOPLIST_KEY_NSMicrophoneUsageDescription: "音声メモを録音するためにマイクを使用します。"
+        INFOPLIST_KEY_NSSpeechRecognitionUsageDescription: "録音した音声メモを文字起こしするために使用します。"
+        INFOPLIST_KEY_NSCameraUsageDescription: "食事記録の写真を撮影するために使用します。"
+        INFOPLIST_KEY_NSPhotoLibraryUsageDescription: "食事記録の写真をライブラリから選択するために使用します。"
+        INFOPLIST_KEY_NSSupportsLiveActivities: YES
+    dependencies:
+      - target: DailyLogWidget
+
+  DailyLogTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: DailyLogTests
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.coco.daily-log.tests
+        GENERATE_INFOPLIST_FILE: YES
+    dependencies:
+      - target: DailyLog
+
+  DailyLogWidget:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: DailyLogWidget
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.coco.daily-log.widget
+        PRODUCT_NAME: DailyLogWidget
+        CODE_SIGN_ENTITLEMENTS: DailyLogWidget/DailyLogWidget.entitlements
+        GENERATE_INFOPLIST_FILE: NO
+        INFOPLIST_FILE: DailyLogWidget/Info.plist
+
+schemes:
+  DailyLog:
+    build:
+      targets:
+        DailyLog: all
+        DailyLogWidget: all
+        DailyLogTests: [test]
+    test:
+      targets:
+        - DailyLogTests
+      gatherCoverageData: true
+    run:
+      config: Debug


### PR DESCRIPTION
## Summary
- `ios/project.yml` を新規作成し、DailyLog / DailyLogTests / DailyLogWidget の 3 ターゲットを定義
- Bundle ID / App Group (`group.com.coco.daily-log`) / iCloud Container (`iCloud.com.coco.daily-log`) を entitlements で設定
- iOS 17.0 / Swift 5.9 / strict concurrency complete / 縦向き固定
- 必要な権限キー (Microphone, SpeechRecognition, Camera, PhotoLibrary, LiveActivities) を `INFOPLIST_KEY_*` で注入
- `ios/Makefile` に `generate / build / test / lint / format` の shortcut を追加
- `.xcodeproj` は追跡外 (xcodegen で再生成)

## Verification
Xcode 26.4 ローカルで確認済み:
- `xcodebuild build` → `** BUILD SUCCEEDED **`
- `xcodebuild test` → `** TEST SUCCEEDED **` (プレースホルダ 1 件 pass)

## Notes
- Widget Extension の Info.plist は、`NSExtension` が nested dict なため `INFOPLIST_KEY_*` で注入できず、最初の build 後の test install で失敗。対処として手書きの `DailyLogWidget/Info.plist` を追加
- Push Notifications capability (Live Activity 用) は #24 の Apple Developer Portal 設定が終わってから #19 (Live Activity 実装) で有効化予定

Closes #2
Refs #24

## Test plan
- [x] `xcodegen generate` が成功
- [x] `xcodebuild build` (iPhone 17 sim) が成功
- [x] `xcodebuild test` (iPhone 17 sim) が成功
- [ ] Xcode GUI で `open ios/DailyLog.xcodeproj` → Run でシミュレータ起動確認 (任意)