### PR TITLE
TASK-3: Swift 用 CI を追加 (xcodebuild + SwiftLint/SwiftFormat)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint / Format
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        run: brew install swiftlint swiftformat
+
+      - name: SwiftFormat (lint)
+        run: swiftformat --lint --config .swiftformat ios
+
+      - name: SwiftLint (strict)
+        run: swiftlint --strict --config .swiftlint.yml
+
+  test:
+    name: Build & Test
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Install xcodegen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        run: make -C ios generate
+
+      - name: Resolve iOS Simulator destination
+        id: sim
+        run: |
+          # 最新の iPhone シミュレータを 1 台選ぶ。新 Xcode でも古い Xcode でも動くよう
+          # `xcrun simctl list devices available` から最初の iPhone 行を拾う。
+          DEVICE=$(xcrun simctl list devices available | \
+            awk -F'[()]' '/-- iOS/{flag=1; next} /^--/{flag=0} flag && /iPhone/ {print $0; exit}' | \
+            sed -E 's/^ *([^(]+) .*/\1/' | \
+            sed -E 's/[[:space:]]+$//')
+          if [ -z "$DEVICE" ]; then
+            echo "::error::No iPhone simulator available"
+            exit 1
+          fi
+          echo "device=$DEVICE" >> "$GITHUB_OUTPUT"
+          echo "Using simulator: $DEVICE"
+
+      - name: Build
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project ios/DailyLog.xcodeproj \
+            -scheme DailyLog \
+            -destination "platform=iOS Simulator,name=${{ steps.sim.outputs.device }},OS=latest" \
+            -configuration Debug \
+            build
+
+      - name: Test
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -project ios/DailyLog.xcodeproj \
+            -scheme DailyLog \
+            -destination "platform=iOS Simulator,name=${{ steps.sim.outputs.device }},OS=latest" \
+            test

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,11 @@
+--swiftversion 5.9
+--indent 4
+--maxwidth 120
+--wraparguments before-first
+--wrapparameters before-first
+--wrapcollections before-first
+--trimwhitespace always
+--stripunusedargs closure-only
+--self remove
+--importgrouping alphabetized
+--exclude ios/DailyLog.xcodeproj,ios/build,ios/DerivedData,ios/.build

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,41 @@
+included:
+  - ios
+
+excluded:
+  - ios/DailyLog.xcodeproj
+  - ios/build
+  - ios/DerivedData
+  - ios/.build
+
+disabled_rules:
+  - trailing_whitespace  # SwiftFormat が管理
+
+opt_in_rules:
+  - empty_count
+  - explicit_init
+  - first_where
+  - force_unwrapping
+  - redundant_nil_coalescing
+  - sorted_imports
+
+line_length:
+  warning: 120
+  error: 160
+  ignores_comments: true
+  ignores_urls: true
+
+identifier_name:
+  min_length: 2
+
+type_name:
+  min_length: 3
+
+file_length:
+  warning: 500
+  error: 800
+
+function_body_length:
+  warning: 60
+  error: 120
+
+reporter: "github-actions-logging"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,87 @@
 # daily-log
+
+行動時間と食事を記録する iOS アプリ。
+
+## 技術スタック
+
+- **言語**: Swift 5.9
+- **UI**: SwiftUI
+- **永続化**: SwiftData + CloudKit (iCloud 同期)
+- **ターゲット**: iOS 17.0+
+- **プロジェクト生成**: [xcodegen](https://github.com/yonaskolb/XcodeGen) (`ios/project.yml`)
+- **Lint/Format**: SwiftLint + SwiftFormat
+- **テスト**: XCTest
+- **ウィジェット**: WidgetKit (App Group で本体アプリとデータ共有)
+
+## 初回セットアップ
+
+### 必要ツール (Homebrew)
+
+```bash
+brew install xcodegen swiftlint swiftformat
+```
+
+Xcode 15 以上を App Store からインストール後、
+
+```bash
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+```
+
+### Xcode プロジェクトの生成
+
+`.xcodeproj` は追跡外なのでクローン直後に生成する。
+
+```bash
+make -C ios generate
+```
+
+`ios/DailyLog.xcodeproj` が作られるので、そのまま Xcode で開ける。
+
+## よく使うコマンド
+
+```bash
+make -C ios generate      # project.yml から .xcodeproj を再生成
+make -C ios build         # iPhone シミュレータ向けに Debug ビルド
+make -C ios test          # XCTest 実行
+make -C ios lint          # SwiftLint strict
+make -C ios format-check  # SwiftFormat dry-run
+make -C ios format        # SwiftFormat 適用
+make -C ios clean         # .xcodeproj / build / DerivedData を削除
+```
+
+## ディレクトリ構成
+
+```
+ios/
+├── project.yml              # xcodegen 定義
+├── Makefile                 # ショートカット
+├── DailyLog/                # アプリ本体
+│   ├── DailyLogApp.swift
+│   ├── ContentView.swift
+│   ├── DailyLog.entitlements  # App Group + iCloud CloudKit
+│   └── Assets.xcassets/
+├── DailyLogTests/           # ユニットテスト
+└── DailyLogWidget/          # ホーム画面ウィジェット (App Extension)
+    ├── DailyLogWidgetBundle.swift
+    ├── DailyLogWidget.swift
+    ├── DailyLogWidget.entitlements
+    └── Info.plist
+```
+
+## 識別子
+
+| 種別 | 値 |
+|---|---|
+| App Bundle ID | `com.coco.daily-log` |
+| Widget Bundle ID | `com.coco.daily-log.widget` |
+| App Group | `group.com.coco.daily-log` |
+| iCloud Container | `iCloud.com.coco.daily-log` |
+
+## 開発フロー
+
+詳細は [CLAUDE.md](./CLAUDE.md) を参照。
+
+1. GitHub Issues でタスクを管理 (`priority:critical` → `priority:high` 順)
+2. `feature/<TASK-ID>-<description>` ブランチで 1 issue ずつ実装
+3. ローカルで `make -C ios lint && make -C ios format-check && make -C ios test` が通ることを確認
+4. PR → CI 緑 → squash merge

--- a/ios/DailyLogTests/DailyLogTests.swift
+++ b/ios/DailyLogTests/DailyLogTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import DailyLog
+import XCTest
 
 final class DailyLogTests: XCTestCase {
     func testPlaceholder() {

--- a/ios/Makefile
+++ b/ios/Makefile
@@ -13,11 +13,6 @@ build: generate
 		-scheme $(SCHEME) \
 		-destination '$(DESTINATION)' \
 		-configuration Debug \
-		build | xcbeautify || xcodebuild \
-		-project $(PROJECT) \
-		-scheme $(SCHEME) \
-		-destination '$(DESTINATION)' \
-		-configuration Debug \
 		build
 
 test: generate


### PR DESCRIPTION
## Summary
- `.github/workflows/ci.yml` を新規作成 (2 ジョブ, macos-latest)
  - **lint**: SwiftFormat `--lint` → SwiftLint `--strict`
  - **test**: xcodegen generate → xcodebuild build → xcodebuild test (iPhone シミュレータ自動選択)
- `.swiftlint.yml` / `.swiftformat` を追加
  - import 順は `sorted_imports` / `--importgrouping alphabetized` で一致させた
- `README.md` を Swift/iOS 向けに全面書き換え (必要ツール, コマンド一覧, 構成, 識別子表)
- `ios/Makefile`: 壊れていた `xcbeautify` fallback (xcodebuild が二重実行される) を削除
- `DailyLogTests.swift`: `@testable import DailyLog` を先頭に並べ替え

## Verification (local, Xcode 26.4 / iPhone 17 simulator)
- [x] `swiftformat --lint --config .swiftformat ios` → 0 require formatting
- [x] `swiftlint --strict --config .swiftlint.yml` → 0 violations
- [x] `make -C ios build` → BUILD SUCCEEDED
- [x] `make -C ios test` → TEST SUCCEEDED

Closes #3

## Test plan
- [ ] CI の lint ジョブが緑
- [ ] CI の test ジョブが緑 (シミュレータ選択ロジックが GitHub runner で動く)
- [ ] 以降の PR で CI が自動実行される