### PR TITLE
TASK-7: 行動開始/停止ロジック (ActivityService + HomeView 配線)

### DIFF
--- a/ios/DailyLog/Services/ActivityService.swift
+++ b/ios/DailyLog/Services/ActivityService.swift
@@ -1,0 +1,51 @@
+import Foundation
+import SwiftData
+
+/// 行動の開始/停止ロジック。
+///
+/// **不変条件**: 進行中の `Activity` (`endAt == nil`) は常に高々 1 件。
+/// `start` は既存の進行中を全て停止してから新規作成する。
+@MainActor
+struct ActivityService {
+    private let context: ModelContext
+
+    init(context: ModelContext) {
+        self.context = context
+    }
+
+    /// 既存の進行中があれば停止し、指定テンプレートで新しい Activity を開始する。
+    @discardableResult
+    func start(template: ActivityTemplate, at now: Date = Date()) throws -> Activity {
+        _ = try stopAllInProgress(at: now)
+        let activity = Activity(template: template, startAt: now)
+        context.insert(activity)
+        try context.save()
+        return activity
+    }
+
+    /// 最も古い進行中を 1 件停止して返す。複数ある場合は防御的に全て停止する。
+    @discardableResult
+    func stopCurrent(at now: Date = Date()) throws -> Activity? {
+        let closed = try stopAllInProgress(at: now)
+        return closed.first
+    }
+
+    func fetchInProgress() throws -> [Activity] {
+        let descriptor = FetchDescriptor<Activity>(
+            predicate: #Predicate { $0.endAt == nil },
+            sortBy: [SortDescriptor(\Activity.startAt)]
+        )
+        return try context.fetch(descriptor)
+    }
+
+    @discardableResult
+    private func stopAllInProgress(at now: Date) throws -> [Activity] {
+        let inProgress = try fetchInProgress()
+        guard !inProgress.isEmpty else { return [] }
+        for activity in inProgress {
+            activity.endAt = now
+        }
+        try context.save()
+        return inProgress
+    }
+}

--- a/ios/DailyLog/Views/HomeView.swift
+++ b/ios/DailyLog/Views/HomeView.swift
@@ -2,6 +2,8 @@ import SwiftData
 import SwiftUI
 
 struct HomeView: View {
+    @Environment(\.modelContext) private var modelContext
+
     @Query(
         filter: #Predicate<Activity> { $0.endAt == nil },
         sort: \Activity.startAt,
@@ -15,8 +17,14 @@ struct HomeView: View {
     )
     private var rootTemplates: [ActivityTemplate]
 
+    @State private var errorMessage: String?
+
     private var currentActivity: Activity? {
         inProgressActivities.first
+    }
+
+    private var service: ActivityService {
+        ActivityService(context: modelContext)
     }
 
     var body: some View {
@@ -39,17 +47,34 @@ struct HomeView: View {
                 .padding(.top)
             }
             .navigationTitle("DailyLog")
+            .alert(
+                "エラー",
+                isPresented: Binding(
+                    get: { errorMessage != nil },
+                    set: { if !$0 { errorMessage = nil } }
+                ),
+                presenting: errorMessage
+            ) { _ in
+                Button("OK", role: .cancel) { errorMessage = nil }
+            } message: { message in
+                Text(message)
+            }
         }
     }
 
-    // MARK: - Placeholder handlers (wired up in #7)
-
     private func stopCurrent() {
-        // #7 で実装
+        do {
+            try service.stopCurrent()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 
     private func start(with template: ActivityTemplate) {
-        // #7 で実装
-        _ = template
+        do {
+            try service.start(template: template)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 }

--- a/ios/DailyLogTests/ActivityServiceTests.swift
+++ b/ios/DailyLogTests/ActivityServiceTests.swift
@@ -1,0 +1,101 @@
+@testable import DailyLog
+import SwiftData
+import XCTest
+
+@MainActor
+final class ActivityServiceTests: XCTestCase {
+    private var container: ModelContainer!
+    private var service: ActivityService!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        container = try AppModelContainer.makeContainer(inMemory: true)
+        service = ActivityService(context: container.mainContext)
+    }
+
+    override func tearDownWithError() throws {
+        service = nil
+        container = nil
+        try super.tearDownWithError()
+    }
+
+    func testStartCreatesInProgressActivity() throws {
+        let template = ActivityTemplate(name: "仕事")
+        container.mainContext.insert(template)
+
+        let activity = try service.start(template: template)
+
+        XCTAssertTrue(activity.isInProgress)
+        XCTAssertEqual(activity.template?.name, "仕事")
+
+        let open = try service.fetchInProgress()
+        XCTAssertEqual(open.count, 1)
+    }
+
+    func testStartAutomaticallyStopsPreviousActivity() throws {
+        let first = ActivityTemplate(name: "勉強")
+        let second = ActivityTemplate(name: "休憩")
+        container.mainContext.insert(first)
+        container.mainContext.insert(second)
+
+        let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+        let t1 = t0.addingTimeInterval(600)
+
+        let firstActivity = try service.start(template: first, at: t0)
+        let secondActivity = try service.start(template: second, at: t1)
+
+        XCTAssertEqual(firstActivity.endAt, t1)
+        XCTAssertFalse(firstActivity.isInProgress)
+        XCTAssertTrue(secondActivity.isInProgress)
+
+        let open = try service.fetchInProgress()
+        XCTAssertEqual(open.count, 1)
+        XCTAssertEqual(open.first?.template?.name, "休憩")
+    }
+
+    func testStopCurrentClosesOpenActivity() throws {
+        let template = ActivityTemplate(name: "運動")
+        container.mainContext.insert(template)
+
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        let end = start.addingTimeInterval(1800)
+
+        let activity = try service.start(template: template, at: start)
+        let stopped = try service.stopCurrent(at: end)
+
+        XCTAssertEqual(stopped?.id, activity.id)
+        XCTAssertEqual(activity.endAt, end)
+        XCTAssertFalse(activity.isInProgress)
+
+        let open = try service.fetchInProgress()
+        XCTAssertTrue(open.isEmpty)
+    }
+
+    func testStopCurrentWithNothingRunningReturnsNil() throws {
+        let stopped = try service.stopCurrent()
+        XCTAssertNil(stopped)
+    }
+
+    func testDefensivelyClosesMultipleInProgress() throws {
+        // 何らかの理由で 2 件進行中になった状態を作り、stopCurrent が全て閉じることを確認
+        let template = ActivityTemplate(name: "仕事")
+        container.mainContext.insert(template)
+
+        let a1 = Activity(template: template, startAt: Date(timeIntervalSinceNow: -120))
+        let a2 = Activity(template: template, startAt: Date(timeIntervalSinceNow: -60))
+        container.mainContext.insert(a1)
+        container.mainContext.insert(a2)
+        try container.mainContext.save()
+
+        let endAt = Date()
+        _ = try service.stopCurrent(at: endAt)
+
+        XCTAssertFalse(a1.isInProgress)
+        XCTAssertFalse(a2.isInProgress)
+        XCTAssertEqual(a1.endAt, endAt)
+        XCTAssertEqual(a2.endAt, endAt)
+
+        let open = try service.fetchInProgress()
+        XCTAssertTrue(open.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- `ActivityService` を追加し、HomeView の start/stop no-op を実ロジックに差し替え
- 不変条件: 進行中 (`endAt == nil`) は常に高々 1 件。`start` は既存の進行中を全て閉じてから新規作成
- エラー発生時は HomeView 上部にアラート表示 (`errorMessage` state binding)

## ActivityService API
- `start(template:at:)` → 既存進行中を全停止 → 新規 Activity 作成 → `save`
- `stopCurrent(at:)` → 開いている全 Activity の `endAt` を設定
- `fetchInProgress()` → `#Predicate { $0.endAt == nil }`, `startAt` 昇順

## Tests (+5 / 19 total)
- `start` で in-progress が 1 件できる
- 進行中があるときの `start` は既存を `endAt = 新 startAt` で閉じる
- `stopCurrent` は開いている Activity を閉じて返す
- 進行中ゼロのとき `stopCurrent` は nil
- (防御) 事前に 2 件進行中を仕込んだ場合でも `stopCurrent` が全部閉じる

## Verification (local)
- [x] `swiftformat --lint` / `swiftlint --strict` clean
- [x] `make -C ios build` SUCCEEDED
- [x] `make -C ios test` 19/19 passed

Closes #7