### PR TITLE
TASK-8: テンプレート管理画面 (一覧/追加/編集/並び替え/削除)

### DIFF
--- a/ios/DailyLog/Models/ActivityTemplate.swift
+++ b/ios/DailyLog/Models/ActivityTemplate.swift
@@ -9,6 +9,7 @@ final class ActivityTemplate {
     var colorHex: String = "#4A90E2"
     var sortOrder: Int = 0
     var reminderMinutes: Int?
+    var isMealType: Bool = false
     var createdAt: Date = Date()
 
     var parent: ActivityTemplate?
@@ -26,6 +27,7 @@ final class ActivityTemplate {
         colorHex: String = "#4A90E2",
         sortOrder: Int = 0,
         reminderMinutes: Int? = nil,
+        isMealType: Bool = false,
         parent: ActivityTemplate? = nil,
         createdAt: Date = Date()
     ) {
@@ -35,6 +37,7 @@ final class ActivityTemplate {
         self.colorHex = colorHex
         self.sortOrder = sortOrder
         self.reminderMinutes = reminderMinutes
+        self.isMealType = isMealType
         self.parent = parent
         self.createdAt = createdAt
     }

--- a/ios/DailyLog/Models/AppModelContainer.swift
+++ b/ios/DailyLog/Models/AppModelContainer.swift
@@ -32,7 +32,8 @@ enum AppModelContainer {
                     iconName: preset.iconName,
                     colorHex: preset.colorHex,
                     sortOrder: index,
-                    reminderMinutes: preset.reminderMinutes
+                    reminderMinutes: preset.reminderMinutes,
+                    isMealType: preset.isMealType
                 )
                 context.insert(template)
             }

--- a/ios/DailyLog/Models/DefaultTemplates.swift
+++ b/ios/DailyLog/Models/DefaultTemplates.swift
@@ -6,16 +6,29 @@ enum DefaultTemplates {
         let iconName: String
         let colorHex: String
         let reminderMinutes: Int?
+        let isMealType: Bool
     }
 
     static let presets: [Preset] = [
-        Preset(name: "睡眠", iconName: "moon.fill", colorHex: "#6F5BE8", reminderMinutes: nil),
-        Preset(name: "食事", iconName: "fork.knife", colorHex: "#F5A623", reminderMinutes: nil),
-        Preset(name: "仕事", iconName: "briefcase.fill", colorHex: "#4A90E2", reminderMinutes: 60),
-        Preset(name: "勉強", iconName: "book.fill", colorHex: "#50C9BA", reminderMinutes: 45),
-        Preset(name: "運動", iconName: "figure.run", colorHex: "#E95E77", reminderMinutes: nil),
-        Preset(name: "移動", iconName: "tram.fill", colorHex: "#7F8C8D", reminderMinutes: nil),
-        Preset(name: "休憩", iconName: "cup.and.saucer.fill", colorHex: "#BFAE82", reminderMinutes: nil),
-        Preset(name: "趣味", iconName: "gamecontroller.fill", colorHex: "#9B59B6", reminderMinutes: nil),
+        Preset(name: "睡眠", iconName: "moon.fill", colorHex: "#6F5BE8", reminderMinutes: nil, isMealType: false),
+        Preset(name: "食事", iconName: "fork.knife", colorHex: "#F5A623", reminderMinutes: nil, isMealType: true),
+        Preset(name: "仕事", iconName: "briefcase.fill", colorHex: "#4A90E2", reminderMinutes: 60, isMealType: false),
+        Preset(name: "勉強", iconName: "book.fill", colorHex: "#50C9BA", reminderMinutes: 45, isMealType: false),
+        Preset(name: "運動", iconName: "figure.run", colorHex: "#E95E77", reminderMinutes: nil, isMealType: false),
+        Preset(name: "移動", iconName: "tram.fill", colorHex: "#7F8C8D", reminderMinutes: nil, isMealType: false),
+        Preset(
+            name: "休憩",
+            iconName: "cup.and.saucer.fill",
+            colorHex: "#BFAE82",
+            reminderMinutes: nil,
+            isMealType: false
+        ),
+        Preset(
+            name: "趣味",
+            iconName: "gamecontroller.fill",
+            colorHex: "#9B59B6",
+            reminderMinutes: nil,
+            isMealType: false
+        ),
     ]
 }

--- a/ios/DailyLog/Services/TemplateService.swift
+++ b/ios/DailyLog/Services/TemplateService.swift
@@ -1,0 +1,68 @@
+import Foundation
+import SwiftData
+
+@MainActor
+struct TemplateService {
+    private let context: ModelContext
+
+    init(context: ModelContext) {
+        self.context = context
+    }
+
+    @discardableResult
+    func create(
+        name: String,
+        iconName: String = "circle",
+        colorHex: String = "#4A90E2",
+        reminderMinutes: Int? = nil,
+        isMealType: Bool = false,
+        parent: ActivityTemplate? = nil
+    ) throws -> ActivityTemplate {
+        let nextOrder = try (siblings(of: parent).map(\.sortOrder).max() ?? -1) + 1
+        let template = ActivityTemplate(
+            name: name,
+            iconName: iconName,
+            colorHex: colorHex,
+            sortOrder: nextOrder,
+            reminderMinutes: reminderMinutes,
+            isMealType: isMealType,
+            parent: parent
+        )
+        context.insert(template)
+        try context.save()
+        return template
+    }
+
+    func save() throws {
+        try context.save()
+    }
+
+    func delete(_ template: ActivityTemplate) throws {
+        context.delete(template)
+        try context.save()
+    }
+
+    func reorder(
+        siblings ordered: [ActivityTemplate],
+        from source: IndexSet,
+        to destination: Int
+    ) throws {
+        var array = ordered
+        array.move(fromOffsets: source, toOffset: destination)
+        for (index, template) in array.enumerated() {
+            template.sortOrder = index
+        }
+        try context.save()
+    }
+
+    func siblings(of parent: ActivityTemplate?) throws -> [ActivityTemplate] {
+        if let parent {
+            return parent.children.sorted { $0.sortOrder < $1.sortOrder }
+        } else {
+            let all = try context.fetch(FetchDescriptor<ActivityTemplate>())
+            return all
+                .filter { $0.parent == nil }
+                .sorted { $0.sortOrder < $1.sortOrder }
+        }
+    }
+}

--- a/ios/DailyLog/Views/HomeView.swift
+++ b/ios/DailyLog/Views/HomeView.swift
@@ -18,6 +18,7 @@ struct HomeView: View {
     private var rootTemplates: [ActivityTemplate]
 
     @State private var errorMessage: String?
+    @State private var isPresentingTemplates = false
 
     private var currentActivity: Activity? {
         inProgressActivities.first
@@ -47,6 +48,19 @@ struct HomeView: View {
                 .padding(.top)
             }
             .navigationTitle("DailyLog")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        isPresentingTemplates = true
+                    } label: {
+                        Image(systemName: "square.grid.2x2")
+                    }
+                    .accessibilityLabel("テンプレート管理")
+                }
+            }
+            .sheet(isPresented: $isPresentingTemplates) {
+                TemplateListView()
+            }
             .alert(
                 "エラー",
                 isPresented: Binding(

--- a/ios/DailyLog/Views/Templates/ColorPaletteView.swift
+++ b/ios/DailyLog/Views/Templates/ColorPaletteView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct ColorPaletteView: View {
+    @Binding var selected: String
+
+    static let palette: [String] = [
+        "#4A90E2", "#F5A623", "#6F5BE8", "#50C9BA",
+        "#E95E77", "#7F8C8D", "#BFAE82", "#9B59B6",
+        "#2ECC71", "#E67E22", "#E74C3C", "#34495E",
+    ]
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 10), count: 6)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("カラー")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            LazyVGrid(columns: columns, spacing: 10) {
+                ForEach(Self.palette, id: \.self) { hex in
+                    Button {
+                        selected = hex
+                    } label: {
+                        Circle()
+                            .fill(Color(hex: hex) ?? .accentColor)
+                            .frame(height: 36)
+                            .overlay(
+                                Circle()
+                                    .strokeBorder(
+                                        selected == hex ? Color.primary : Color.clear,
+                                        lineWidth: 3
+                                    )
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(hex)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/ios/DailyLog/Views/Templates/SymbolPickerView.swift
+++ b/ios/DailyLog/Views/Templates/SymbolPickerView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct SymbolPickerView: View {
+    @Binding var selected: String
+    @Environment(\.dismiss) private var dismiss
+    @State private var search: String = ""
+
+    static let allSymbols: [String] = [
+        "circle", "square", "star.fill", "heart.fill", "flag.fill",
+        "clock", "timer", "calendar", "bell", "hourglass",
+        "moon.fill", "sun.max.fill", "cloud.fill", "leaf.fill", "flame.fill",
+        "fork.knife", "cup.and.saucer.fill", "wineglass.fill", "takeoutbag.and.cup.and.straw.fill", "birthday.cake",
+        "book.fill", "book.closed", "graduationcap.fill", "pencil", "highlighter",
+        "briefcase.fill", "display", "keyboard", "laptopcomputer", "printer.fill",
+        "figure.run", "figure.walk", "dumbbell.fill", "sportscourt", "figure.pool.swim",
+        "tram.fill", "car.fill", "bicycle", "airplane", "bus",
+        "gamecontroller.fill", "music.note", "headphones", "film.fill", "tv",
+        "person.fill", "person.2.fill", "house.fill", "bed.double.fill", "shower.fill",
+        "cart.fill", "creditcard.fill", "dollarsign.circle.fill", "bag.fill", "gift.fill",
+        "cross.case.fill", "pills.fill", "stethoscope", "brain.head.profile", "lungs.fill",
+    ]
+
+    private var filtered: [String] {
+        if search.isEmpty { return Self.allSymbols }
+        let query = search.lowercased()
+        return Self.allSymbols.filter { $0.lowercased().contains(query) }
+    }
+
+    private let columns = [GridItem(.adaptive(minimum: 64), spacing: 12)]
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: columns, spacing: 12) {
+                ForEach(filtered, id: \.self) { symbol in
+                    SymbolCell(symbol: symbol, isSelected: selected == symbol) {
+                        selected = symbol
+                        dismiss()
+                    }
+                }
+            }
+            .padding()
+        }
+        .searchable(text: $search, prompt: "検索")
+        .navigationTitle("アイコン選択")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private struct SymbolCell: View {
+    let symbol: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: symbol)
+                .font(.title2)
+                .frame(width: 56, height: 56)
+                .background(background)
+                .overlay(border)
+                .foregroundStyle(.primary)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(symbol)
+    }
+
+    private var background: some View {
+        RoundedRectangle(cornerRadius: 12)
+            .fill(isSelected ? Color.accentColor.opacity(0.2) : Color(.secondarySystemBackground))
+    }
+
+    private var border: some View {
+        RoundedRectangle(cornerRadius: 12)
+            .strokeBorder(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
+    }
+}

--- a/ios/DailyLog/Views/Templates/TemplateEditView.swift
+++ b/ios/DailyLog/Views/Templates/TemplateEditView.swift
@@ -1,0 +1,146 @@
+import SwiftData
+import SwiftUI
+
+struct TemplateEditView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    let existing: ActivityTemplate?
+
+    @Query(sort: \ActivityTemplate.sortOrder)
+    private var allTemplates: [ActivityTemplate]
+
+    @State private var name: String = ""
+    @State private var iconName: String = "circle"
+    @State private var colorHex: String = "#4A90E2"
+    @State private var parentID: UUID?
+    @State private var hasReminder: Bool = false
+    @State private var reminderMinutes: Int = 30
+    @State private var isMealType: Bool = false
+    @State private var errorMessage: String?
+
+    private var service: TemplateService {
+        TemplateService(context: modelContext)
+    }
+
+    private var parentCandidates: [ActivityTemplate] {
+        guard let existing else { return allTemplates.filter { $0.parent == nil } }
+        let forbidden = Set([existing.id] + existing.children.map(\.id))
+        return allTemplates.filter { !forbidden.contains($0.id) }
+    }
+
+    private var isSaveDisabled: Bool {
+        name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("基本") {
+                    TextField("名前", text: $name)
+
+                    NavigationLink {
+                        SymbolPickerView(selected: $iconName)
+                    } label: {
+                        HStack {
+                            Text("アイコン")
+                            Spacer()
+                            Image(systemName: iconName)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    ColorPaletteView(selected: $colorHex)
+                }
+
+                Section("分類") {
+                    Picker("親テンプレ", selection: $parentID) {
+                        Text("なし").tag(nil as UUID?)
+                        ForEach(parentCandidates) { template in
+                            Text(template.name).tag(template.id as UUID?)
+                        }
+                    }
+
+                    Toggle("食事タイプ", isOn: $isMealType)
+                }
+
+                Section("リマインダー") {
+                    Toggle("忘れアラートを使う", isOn: $hasReminder)
+                    if hasReminder {
+                        Stepper("\(reminderMinutes) 分後", value: $reminderMinutes, in: 5 ... 240, step: 5)
+                    }
+                }
+            }
+            .navigationTitle(existing == nil ? "新規テンプレ" : "編集")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("キャンセル") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("保存", action: save)
+                        .disabled(isSaveDisabled)
+                }
+            }
+            .onAppear(perform: loadFromExisting)
+            .alert(
+                "エラー",
+                isPresented: Binding(
+                    get: { errorMessage != nil },
+                    set: { if !$0 { errorMessage = nil } }
+                ),
+                presenting: errorMessage
+            ) { _ in
+                Button("OK", role: .cancel) { errorMessage = nil }
+            } message: { message in
+                Text(message)
+            }
+        }
+    }
+
+    private func loadFromExisting() {
+        guard let existing else { return }
+        name = existing.name
+        iconName = existing.iconName
+        colorHex = existing.colorHex
+        parentID = existing.parent?.id
+        if let minutes = existing.reminderMinutes {
+            hasReminder = true
+            reminderMinutes = minutes
+        } else {
+            hasReminder = false
+            reminderMinutes = 30
+        }
+        isMealType = existing.isMealType
+    }
+
+    private func save() {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let effectiveReminder: Int? = hasReminder ? reminderMinutes : nil
+        let parent = parentID.flatMap { id in allTemplates.first(where: { $0.id == id }) }
+
+        do {
+            if let existing {
+                existing.name = trimmedName
+                existing.iconName = iconName
+                existing.colorHex = colorHex
+                existing.parent = parent
+                existing.reminderMinutes = effectiveReminder
+                existing.isMealType = isMealType
+                try service.save()
+            } else {
+                try service.create(
+                    name: trimmedName,
+                    iconName: iconName,
+                    colorHex: colorHex,
+                    reminderMinutes: effectiveReminder,
+                    isMealType: isMealType,
+                    parent: parent
+                )
+            }
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ios/DailyLog/Views/Templates/TemplateListView.swift
+++ b/ios/DailyLog/Views/Templates/TemplateListView.swift
@@ -1,0 +1,90 @@
+import SwiftData
+import SwiftUI
+
+struct TemplateListView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    @Query(
+        filter: #Predicate<ActivityTemplate> { $0.parent == nil },
+        sort: \ActivityTemplate.sortOrder
+    )
+    private var rootTemplates: [ActivityTemplate]
+
+    @State private var editing: ActivityTemplate?
+    @State private var isPresentingNew = false
+    @State private var errorMessage: String?
+
+    private var service: TemplateService {
+        TemplateService(context: modelContext)
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(rootTemplates) { template in
+                    Button {
+                        editing = template
+                    } label: {
+                        TemplateRow(template: template)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .onMove(perform: move)
+                .onDelete(perform: delete)
+            }
+            .navigationTitle("テンプレート")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    EditButton()
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        isPresentingNew = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("閉じる") { dismiss() }
+                }
+            }
+            .sheet(item: $editing) { template in
+                TemplateEditView(existing: template)
+            }
+            .sheet(isPresented: $isPresentingNew) {
+                TemplateEditView(existing: nil)
+            }
+            .alert(
+                "エラー",
+                isPresented: Binding(
+                    get: { errorMessage != nil },
+                    set: { if !$0 { errorMessage = nil } }
+                ),
+                presenting: errorMessage
+            ) { _ in
+                Button("OK", role: .cancel) { errorMessage = nil }
+            } message: { message in
+                Text(message)
+            }
+        }
+    }
+
+    private func move(from source: IndexSet, to destination: Int) {
+        do {
+            try service.reorder(siblings: rootTemplates, from: source, to: destination)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func delete(at offsets: IndexSet) {
+        for index in offsets {
+            do {
+                try service.delete(rootTemplates[index])
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+}

--- a/ios/DailyLog/Views/Templates/TemplateRow.swift
+++ b/ios/DailyLog/Views/Templates/TemplateRow.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+struct TemplateRow: View {
+    let template: ActivityTemplate
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: template.iconName)
+                .font(.title3)
+                .foregroundStyle(.white)
+                .frame(width: 36, height: 36)
+                .background(
+                    Circle()
+                        .fill(Color(hex: template.colorHex) ?? .accentColor)
+                )
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(template.name)
+                    .font(.body)
+                    .foregroundStyle(.primary)
+
+                HStack(spacing: 6) {
+                    if template.isMealType {
+                        Label("食事", systemImage: "fork.knife.circle")
+                            .labelStyle(.titleAndIcon)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    if let minutes = template.reminderMinutes {
+                        Label("\(minutes)分", systemImage: "bell")
+                            .labelStyle(.titleAndIcon)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    if !template.children.isEmpty {
+                        Label("\(template.children.count)", systemImage: "square.on.square")
+                            .labelStyle(.titleAndIcon)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+
+            Spacer()
+        }
+        .padding(.vertical, 2)
+    }
+}

--- a/ios/DailyLogTests/TemplateServiceTests.swift
+++ b/ios/DailyLogTests/TemplateServiceTests.swift
@@ -46,17 +46,16 @@ final class TemplateServiceTests: XCTestCase {
     }
 
     func testReorderUpdatesSortOrder() throws {
-        let a = try service.create(name: "A")
-        let b = try service.create(name: "B")
-        let c = try service.create(name: "C")
+        let first = try service.create(name: "A")
+        let second = try service.create(name: "B")
+        let third = try service.create(name: "C")
         let siblings = try service.siblings(of: nil)
 
-        // Move last element to front
         try service.reorder(siblings: siblings, from: IndexSet(integer: 2), to: 0)
 
-        XCTAssertEqual(c.sortOrder, 0)
-        XCTAssertEqual(a.sortOrder, 1)
-        XCTAssertEqual(b.sortOrder, 2)
+        XCTAssertEqual(third.sortOrder, 0)
+        XCTAssertEqual(first.sortOrder, 1)
+        XCTAssertEqual(second.sortOrder, 2)
 
         let reloaded = try service.siblings(of: nil)
         XCTAssertEqual(reloaded.map(\.name), ["C", "A", "B"])

--- a/ios/DailyLogTests/TemplateServiceTests.swift
+++ b/ios/DailyLogTests/TemplateServiceTests.swift
@@ -1,0 +1,92 @@
+@testable import DailyLog
+import SwiftData
+import XCTest
+
+@MainActor
+final class TemplateServiceTests: XCTestCase {
+    private var container: ModelContainer!
+    private var service: TemplateService!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        container = try AppModelContainer.makeContainer(inMemory: true)
+        service = TemplateService(context: container.mainContext)
+    }
+
+    override func tearDownWithError() throws {
+        service = nil
+        container = nil
+        try super.tearDownWithError()
+    }
+
+    func testCreateAssignsIncrementingSortOrder() throws {
+        let first = try service.create(name: "A")
+        let second = try service.create(name: "B")
+        let third = try service.create(name: "C")
+
+        XCTAssertEqual(first.sortOrder, 0)
+        XCTAssertEqual(second.sortOrder, 1)
+        XCTAssertEqual(third.sortOrder, 2)
+    }
+
+    func testCreateWithParentUsesParentSiblingSortOrder() throws {
+        let parent = try service.create(name: "親")
+        let child1 = try service.create(name: "子1", parent: parent)
+        let child2 = try service.create(name: "子2", parent: parent)
+
+        // Children are scoped to their parent's siblings, not the global list.
+        XCTAssertEqual(child1.sortOrder, 0)
+        XCTAssertEqual(child2.sortOrder, 1)
+        XCTAssertEqual(child1.parent?.id, parent.id)
+    }
+
+    func testCreateMealTypeFlag() throws {
+        let meal = try service.create(name: "ランチ", isMealType: true)
+        XCTAssertTrue(meal.isMealType)
+    }
+
+    func testReorderUpdatesSortOrder() throws {
+        let a = try service.create(name: "A")
+        let b = try service.create(name: "B")
+        let c = try service.create(name: "C")
+        let siblings = try service.siblings(of: nil)
+
+        // Move last element to front
+        try service.reorder(siblings: siblings, from: IndexSet(integer: 2), to: 0)
+
+        XCTAssertEqual(c.sortOrder, 0)
+        XCTAssertEqual(a.sortOrder, 1)
+        XCTAssertEqual(b.sortOrder, 2)
+
+        let reloaded = try service.siblings(of: nil)
+        XCTAssertEqual(reloaded.map(\.name), ["C", "A", "B"])
+    }
+
+    func testDeleteRemovesTemplate() throws {
+        let template = try service.create(name: "消えるやつ")
+        try service.delete(template)
+
+        let remaining = try service.siblings(of: nil)
+        XCTAssertTrue(remaining.allSatisfy { $0.name != "消えるやつ" })
+    }
+
+    func testDeleteParentCascadesChildren() throws {
+        let parent = try service.create(name: "親")
+        _ = try service.create(name: "子", parent: parent)
+
+        try service.delete(parent)
+
+        let all = try container.mainContext.fetch(FetchDescriptor<ActivityTemplate>())
+        XCTAssertFalse(all.contains { $0.name == "親" })
+        XCTAssertFalse(all.contains { $0.name == "子" })
+    }
+
+    func testSiblingsOfNilReturnsRootTemplatesInOrder() throws {
+        _ = try service.create(name: "root1")
+        let parent = try service.create(name: "root2")
+        _ = try service.create(name: "child", parent: parent)
+
+        let roots = try service.siblings(of: nil)
+        XCTAssertEqual(roots.map(\.name), ["root1", "root2"])
+    }
+}


### PR DESCRIPTION
## Summary
テンプレート CRUD + 並び替え UI と `TemplateService` を追加。`ActivityTemplate` に `isMealType` フラグを追加。

### モデル変更
- `ActivityTemplate.isMealType: Bool = false` 追加
- 既存行は default 値でマイグレーション (CloudKit 互換維持)
- 初期 seed の "食事" を `isMealType = true` に更新

### TemplateService
- `create(...)` — `sortOrder` を親グループの最大 + 1 で自動採番
- `save` / `delete` / `reorder(siblings:from:to:)` — reorder は全兄弟の sortOrder を書き直す
- `siblings(of:)` — 親 nil でルート、指定時は `parent.children` を順序ソート

### 画面
- **HomeView** ツールバーに "square.grid.2x2" ボタン → `TemplateListView` を sheet で表示
- **TemplateListView**: List + `onMove` + swipe delete、＋ボタンで新規、行タップで編集
- **TemplateRow**: アイコン + 名前 + メタ (食事 / リマインダー / 子数)
- **TemplateEditView**: 名前 / アイコン (NavigationLink → `SymbolPickerView`) / カラー (`ColorPaletteView`) / 親 / 食事トグル / リマインダー分数
  - 親候補から自分自身と自分の子を除外 (自己参照ガード)
- **SymbolPickerView**: 約 60 個の SF Symbol を searchable grid。Swift コンパイラの expression-too-complex を避けるためセルを `SymbolCell` に分離
- **ColorPaletteView**: プリセット 12 色

## Tests (+7 / 26 total)
- `create` sortOrder 自動採番 (ルート / 親配下)
- 親配下は親兄弟で独立した sortOrder
- `isMealType` フラグの round-trip
- `reorder` が sortOrder を書き直す
- `delete` 本体 / cascade 子削除
- `siblings(of: nil)` がルートのみ順序どおり

## Verification (local)
- [x] `swiftformat --lint` / `swiftlint --strict` clean
- [x] `make -C ios build` SUCCEEDED
- [x] `make -C ios test` 26/26 passed

## Notes
- 深い循環参照 (A→B→A) の防止は階層が実質フラットな現時点では未対応。#9 で階層 UI が入ったタイミングで再検討
- UI テストは未導入

Closes #8
Refs #9 #12