### PR TITLE
TASK-9: 階層カテゴリ (長押しで子テンプレシート)

### DIFF
--- a/ios/DailyLog/Views/ChildTemplateSheet.swift
+++ b/ios/DailyLog/Views/ChildTemplateSheet.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+struct ChildTemplateSheet: View {
+    let parent: ActivityTemplate
+    let onSelect: (ActivityTemplate) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    private let columns = [GridItem(.adaptive(minimum: 88), spacing: 12)]
+
+    private var sortedChildren: [ActivityTemplate] {
+        parent.children.sorted { $0.sortOrder < $1.sortOrder }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 16) {
+                    header
+
+                    if sortedChildren.isEmpty {
+                        emptyState
+                    } else {
+                        LazyVGrid(columns: columns, spacing: 12) {
+                            ForEach(sortedChildren) { child in
+                                TemplateButton(template: child) {
+                                    onSelect(child)
+                                    dismiss()
+                                }
+                            }
+                        }
+                    }
+
+                    Spacer(minLength: 0)
+                }
+                .padding()
+            }
+            .navigationTitle(parent.name)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("閉じる") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("親で開始") {
+                        onSelect(parent)
+                        dismiss()
+                    }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Image(systemName: parent.iconName)
+                .font(.title2)
+                .foregroundStyle(.white)
+                .frame(width: 44, height: 44)
+                .background(
+                    Circle()
+                        .fill(Color(hex: parent.colorHex) ?? .accentColor)
+                )
+
+            VStack(alignment: .leading) {
+                Text(parent.name)
+                    .font(.headline)
+                Text("子テンプレート \(sortedChildren.count) 個")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "square.grid.2x2")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+            Text("子テンプレートはありません")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 32)
+    }
+}

--- a/ios/DailyLog/Views/HomeView.swift
+++ b/ios/DailyLog/Views/HomeView.swift
@@ -19,6 +19,7 @@ struct HomeView: View {
 
     @State private var errorMessage: String?
     @State private var isPresentingTemplates = false
+    @State private var childrenParent: ActivityTemplate?
 
     private var currentActivity: Activity? {
         inProgressActivities.first
@@ -39,7 +40,14 @@ struct HomeView: View {
 
                     TemplateGrid(
                         templates: rootTemplates,
-                        onTap: { start(with: $0) }
+                        onTap: { start(with: $0) },
+                        onLongPress: { template in
+                            if template.children.isEmpty {
+                                start(with: template)
+                            } else {
+                                childrenParent = template
+                            }
+                        }
                     )
 
                     Spacer(minLength: 0)
@@ -60,6 +68,11 @@ struct HomeView: View {
             }
             .sheet(isPresented: $isPresentingTemplates) {
                 TemplateListView()
+            }
+            .sheet(item: $childrenParent) { parent in
+                ChildTemplateSheet(parent: parent) { selected in
+                    start(with: selected)
+                }
             }
             .alert(
                 "エラー",

--- a/ios/DailyLog/Views/TemplateButton.swift
+++ b/ios/DailyLog/Views/TemplateButton.swift
@@ -3,24 +3,62 @@ import SwiftUI
 struct TemplateButton: View {
     let template: ActivityTemplate
     let action: () -> Void
+    var onLongPress: (() -> Void)?
 
     var body: some View {
         Button(action: action) {
-            VStack(spacing: 6) {
-                Image(systemName: template.iconName)
-                    .font(.title2)
-                Text(template.name)
-                    .font(.caption)
-                    .lineLimit(1)
-            }
-            .foregroundStyle(.white)
-            .frame(maxWidth: .infinity, minHeight: 72)
-            .background(
-                RoundedRectangle(cornerRadius: 14)
-                    .fill(Color(hex: template.colorHex) ?? .accentColor)
-            )
+            label
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(template.name)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint(onLongPress == nil ? "" : "長押しで子テンプレートを表示")
+        .onLongPressGesture(minimumDuration: 0.5) {
+            onLongPress?()
+        }
+    }
+
+    private var label: some View {
+        VStack(spacing: 6) {
+            iconArea
+
+            Text(template.name)
+                .font(.caption)
+                .lineLimit(1)
+        }
+        .foregroundStyle(.white)
+        .frame(maxWidth: .infinity, minHeight: 72)
+        .background(background)
+    }
+
+    private var iconArea: some View {
+        ZStack(alignment: .topTrailing) {
+            Image(systemName: template.iconName)
+                .font(.title2)
+                .frame(maxWidth: .infinity)
+
+            if !template.children.isEmpty {
+                childrenBadge
+            }
+        }
+    }
+
+    private var childrenBadge: some View {
+        Image(systemName: "ellipsis.circle.fill")
+            .font(.caption)
+            .foregroundStyle(.white.opacity(0.9))
+            .background(Circle().fill(.black.opacity(0.25)))
+    }
+
+    private var background: some View {
+        RoundedRectangle(cornerRadius: 14)
+            .fill(Color(hex: template.colorHex) ?? .accentColor)
+    }
+
+    private var accessibilityLabel: String {
+        if template.children.isEmpty {
+            template.name
+        } else {
+            "\(template.name)、\(template.children.count) 個の子テンプレート"
+        }
     }
 }

--- a/ios/DailyLog/Views/TemplateGrid.swift
+++ b/ios/DailyLog/Views/TemplateGrid.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TemplateGrid: View {
     let templates: [ActivityTemplate]
     let onTap: (ActivityTemplate) -> Void
+    var onLongPress: ((ActivityTemplate) -> Void)?
 
     private let columns = [
         GridItem(.adaptive(minimum: 88), spacing: 12),
@@ -14,9 +15,13 @@ struct TemplateGrid: View {
         } else {
             LazyVGrid(columns: columns, spacing: 12) {
                 ForEach(templates) { template in
-                    TemplateButton(template: template) {
-                        onTap(template)
-                    }
+                    TemplateButton(
+                        template: template,
+                        action: { onTap(template) },
+                        onLongPress: onLongPress.map { handler in
+                            { handler(template) }
+                        }
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ホーム画面のテンプレボタンを長押し (0.5s) すると、子テンプレートの一覧シートが開く
- 子を持つテンプレにはアイコン右上に "…" バッジを表示
- 子がいない場合の長押しは開始処理にフォールバック
- シートのツールバーに「親で開始」ボタンを用意

## 実装詳細
- `TemplateButton` に `onLongPress: (() -> Void)?` を追加。ビルド時のコンパイラ時間超過を避けるため label/iconArea/childrenBadge/background にサブビュー分離
- `TemplateGrid` が long-press ハンドラを伝播
- `HomeView` に `childrenParent: ActivityTemplate?` 状態を追加、`.sheet(item:)` で `ChildTemplateSheet` を表示
- `ChildTemplateSheet` — ヘッダー (親の色付きアイコン + 名前 + 子数) / 子グリッド / "親で開始" ツールバー。Medium/Large detents

## Tests
- Service レイヤは #7/#8 で既にカバー (start(template:) は任意のテンプレに対応)
- 追加のテストは必要に応じて UI テスト導入時に

## Verification (local)
- [x] `swiftformat --lint` / `swiftlint --strict` clean
- [x] `make -C ios build` SUCCEEDED
- [x] `make -C ios test` 26/26 passed

Closes #9