### PR TITLE
TASK-10: 忘れアラート (ローカル通知)

### DIFF
--- a/ios/DailyLog/Services/ActivityNotifier.swift
+++ b/ios/DailyLog/Services/ActivityNotifier.swift
@@ -1,0 +1,77 @@
+import Foundation
+import UserNotifications
+
+/// 行動の忘れアラートを扱う抽象。
+///
+/// 本番実装は `LocalNotificationNotifier`、テストはモックに差し替える。
+@MainActor
+protocol ActivityNotifier {
+    func requestAuthorizationIfNeeded() async
+    func scheduleReminder(for activity: Activity)
+    func cancelReminder(for activity: Activity)
+}
+
+@MainActor
+final class LocalNotificationNotifier: ActivityNotifier {
+    static let shared = LocalNotificationNotifier()
+
+    private let center = UNUserNotificationCenter.current()
+    private let identifierPrefix = "activity-reminder-"
+
+    private init() {}
+
+    func requestAuthorizationIfNeeded() async {
+        let settings = await center.notificationSettings()
+        guard settings.authorizationStatus == .notDetermined else { return }
+        _ = try? await center.requestAuthorization(options: [.alert, .sound])
+    }
+
+    func scheduleReminder(for activity: Activity) {
+        guard
+            let template = activity.template,
+            let minutes = template.reminderMinutes,
+            minutes > 0
+        else {
+            return
+        }
+
+        // Activity は Sendable ではないため、必要な値だけコピーして detached Task に渡す。
+        let identifier = identifier(for: activity.id)
+        let templateName = template.name
+
+        Task {
+            await self.scheduleInternal(
+                identifier: identifier,
+                templateName: templateName,
+                minutes: minutes
+            )
+        }
+    }
+
+    func cancelReminder(for activity: Activity) {
+        let identifier = identifier(for: activity.id)
+        center.removePendingNotificationRequests(withIdentifiers: [identifier])
+    }
+
+    private func scheduleInternal(identifier: String, templateName: String, minutes: Int) async {
+        let content = UNMutableNotificationContent()
+        content.title = "まだ\(templateName)してる？"
+        content.body = "\(minutes) 分経過しました。終わっていれば停止してください。"
+        content.sound = .default
+
+        let trigger = UNTimeIntervalNotificationTrigger(
+            timeInterval: TimeInterval(minutes) * 60,
+            repeats: false
+        )
+        let request = UNNotificationRequest(
+            identifier: identifier,
+            content: content,
+            trigger: trigger
+        )
+        _ = try? await center.add(request)
+    }
+
+    private func identifier(for activityID: UUID) -> String {
+        identifierPrefix + activityID.uuidString
+    }
+}

--- a/ios/DailyLog/Services/ActivityService.swift
+++ b/ios/DailyLog/Services/ActivityService.swift
@@ -5,21 +5,28 @@ import SwiftData
 ///
 /// **不変条件**: 進行中の `Activity` (`endAt == nil`) は常に高々 1 件。
 /// `start` は既存の進行中を全て停止してから新規作成する。
+/// 忘れアラートのスケジュール/キャンセルを `ActivityNotifier` 経由で発火する。
 @MainActor
 struct ActivityService {
     private let context: ModelContext
+    private let notifier: any ActivityNotifier
 
-    init(context: ModelContext) {
+    init(context: ModelContext, notifier: any ActivityNotifier = LocalNotificationNotifier.shared) {
         self.context = context
+        self.notifier = notifier
     }
 
     /// 既存の進行中があれば停止し、指定テンプレートで新しい Activity を開始する。
     @discardableResult
     func start(template: ActivityTemplate, at now: Date = Date()) throws -> Activity {
-        _ = try stopAllInProgress(at: now)
+        let closed = try stopAllInProgress(at: now)
+        for activity in closed {
+            notifier.cancelReminder(for: activity)
+        }
         let activity = Activity(template: template, startAt: now)
         context.insert(activity)
         try context.save()
+        notifier.scheduleReminder(for: activity)
         return activity
     }
 
@@ -27,6 +34,9 @@ struct ActivityService {
     @discardableResult
     func stopCurrent(at now: Date = Date()) throws -> Activity? {
         let closed = try stopAllInProgress(at: now)
+        for activity in closed {
+            notifier.cancelReminder(for: activity)
+        }
         return closed.first
     }
 

--- a/ios/DailyLog/Views/HomeView.swift
+++ b/ios/DailyLog/Views/HomeView.swift
@@ -56,6 +56,9 @@ struct HomeView: View {
                 .padding(.top)
             }
             .navigationTitle("DailyLog")
+            .task {
+                await LocalNotificationNotifier.shared.requestAuthorizationIfNeeded()
+            }
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {

--- a/ios/DailyLogTests/ActivityServiceTests.swift
+++ b/ios/DailyLogTests/ActivityServiceTests.swift
@@ -5,22 +5,25 @@ import XCTest
 @MainActor
 final class ActivityServiceTests: XCTestCase {
     private var container: ModelContainer!
+    private var notifier: MockActivityNotifier!
     private var service: ActivityService!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         container = try AppModelContainer.makeContainer(inMemory: true)
-        service = ActivityService(context: container.mainContext)
+        notifier = MockActivityNotifier()
+        service = ActivityService(context: container.mainContext, notifier: notifier)
     }
 
     override func tearDownWithError() throws {
         service = nil
+        notifier = nil
         container = nil
         try super.tearDownWithError()
     }
 
     func testStartCreatesInProgressActivity() throws {
-        let template = ActivityTemplate(name: "仕事")
+        let template = ActivityTemplate(name: "仕事", reminderMinutes: 60)
         container.mainContext.insert(template)
 
         let activity = try service.start(template: template)
@@ -33,7 +36,7 @@ final class ActivityServiceTests: XCTestCase {
     }
 
     func testStartAutomaticallyStopsPreviousActivity() throws {
-        let first = ActivityTemplate(name: "勉強")
+        let first = ActivityTemplate(name: "勉強", reminderMinutes: 45)
         let second = ActivityTemplate(name: "休憩")
         container.mainContext.insert(first)
         container.mainContext.insert(second)
@@ -77,7 +80,6 @@ final class ActivityServiceTests: XCTestCase {
     }
 
     func testDefensivelyClosesMultipleInProgress() throws {
-        // 何らかの理由で 2 件進行中になった状態を作り、stopCurrent が全て閉じることを確認
         let template = ActivityTemplate(name: "仕事")
         container.mainContext.insert(template)
 
@@ -94,8 +96,73 @@ final class ActivityServiceTests: XCTestCase {
         XCTAssertFalse(a2.isInProgress)
         XCTAssertEqual(a1.endAt, endAt)
         XCTAssertEqual(a2.endAt, endAt)
+    }
 
-        let open = try service.fetchInProgress()
-        XCTAssertTrue(open.isEmpty)
+    // MARK: - Reminder notifier integration
+
+    func testStartSchedulesReminderForTemplateWithReminderMinutes() throws {
+        let template = ActivityTemplate(name: "勉強", reminderMinutes: 45)
+        container.mainContext.insert(template)
+
+        let activity = try service.start(template: template)
+
+        XCTAssertTrue(notifier.scheduledIDs.contains(activity.id))
+    }
+
+    func testStartDoesNotScheduleReminderWhenTemplateHasNone() throws {
+        let template = ActivityTemplate(name: "睡眠", reminderMinutes: nil)
+        container.mainContext.insert(template)
+
+        let activity = try service.start(template: template)
+
+        // The mock forwards to the real guard, mirroring production behaviour.
+        XCTAssertFalse(notifier.scheduledIDs.contains(activity.id))
+    }
+
+    func testStartCancelsReminderForReplacedActivity() throws {
+        let first = ActivityTemplate(name: "勉強", reminderMinutes: 45)
+        let second = ActivityTemplate(name: "仕事", reminderMinutes: 60)
+        container.mainContext.insert(first)
+        container.mainContext.insert(second)
+
+        let firstActivity = try service.start(template: first)
+        let secondActivity = try service.start(template: second)
+
+        XCTAssertTrue(notifier.cancelledIDs.contains(firstActivity.id))
+        XCTAssertTrue(notifier.scheduledIDs.contains(secondActivity.id))
+    }
+
+    func testStopCurrentCancelsReminder() throws {
+        let template = ActivityTemplate(name: "仕事", reminderMinutes: 60)
+        container.mainContext.insert(template)
+
+        let activity = try service.start(template: template)
+        _ = try service.stopCurrent()
+
+        XCTAssertTrue(notifier.cancelledIDs.contains(activity.id))
+    }
+}
+
+@MainActor
+private final class MockActivityNotifier: ActivityNotifier {
+    private(set) var scheduledIDs: Set<UUID> = []
+    private(set) var cancelledIDs: Set<UUID> = []
+
+    func requestAuthorizationIfNeeded() async {}
+
+    func scheduleReminder(for activity: Activity) {
+        guard
+            let template = activity.template,
+            let minutes = template.reminderMinutes,
+            minutes > 0
+        else {
+            return
+        }
+        scheduledIDs.insert(activity.id)
+    }
+
+    func cancelReminder(for activity: Activity) {
+        cancelledIDs.insert(activity.id)
+        scheduledIDs.remove(activity.id)
     }
 }


### PR DESCRIPTION
## Summary
`ActivityTemplate.reminderMinutes` が設定されているテンプレで行動を開始すると、指定分数後にローカル通知を発火する。停止 / 別行動開始時に通知をキャンセル。

## 設計
- `ActivityNotifier` protocol を追加し、ActivityService の依存を注入可能に
- 本番は `LocalNotificationNotifier.shared`、テストは `MockActivityNotifier`
- Notification identifier は `activity-reminder-<UUID>` でキャンセル可能
- `Activity` は Sendable ではないため、Task 内に渡す前に `id` / `templateName` / `minutes` のみ取り出す
- HomeView の `.task` で `requestAuthorizationIfNeeded()` を呼ぶ (初回のみ prompt)

## ActivityService 変更
- `start`: stopAllInProgress → cancelReminder(各閉じた Activity) → insert 新規 → scheduleReminder
- `stopCurrent`: cancelReminder(各閉じた Activity)
- 通知処理は全て `notifier` 経由

## Tests (+4 / 30 total)
- `reminderMinutes` あり → schedule される
- `reminderMinutes` なし → schedule されない
- 既存進行中を置き換え → 旧 cancel + 新 schedule
- `stopCurrent` → cancel

## Verification (local)
- [x] `swiftformat --lint` / `swiftlint --strict` clean
- [x] `make -C ios build` SUCCEEDED
- [x] `make -C ios test` 30/30 passed

## Notes
- iOS の通知許可は OS が初回要求時に prompt を出す。Info.plist の使用目的記述は不要
- 通知拒否時は `try? await center.add(...)` が失敗するが silent fallback
- プッシュ通知 capability (Live Activity 用) は #19 で有効化予定、現時点では不要

Closes #10