### PR TITLE
TASK-11: 音声メモ (SFSpeechRecognizer)

### DIFF
--- a/ios/DailyLog/Extensions/Activity+Note.swift
+++ b/ios/DailyLog/Extensions/Activity+Note.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension Activity {
+    /// 既存メモの末尾に新しい内容を追加する。空文字列は無視。
+    /// 既存メモが空でなければ改行で区切る。
+    func appendNote(_ text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        if note.isEmpty {
+            note = trimmed
+        } else {
+            note += "\n" + trimmed
+        }
+    }
+}

--- a/ios/DailyLog/Services/SpeechRecognitionService.swift
+++ b/ios/DailyLog/Services/SpeechRecognitionService.swift
@@ -1,0 +1,105 @@
+import AVFoundation
+import Foundation
+import Speech
+
+@MainActor
+final class SpeechRecognitionService: ObservableObject {
+    @Published private(set) var transcription: String = ""
+    @Published private(set) var isRecording: Bool = false
+    @Published private(set) var errorMessage: String?
+
+    private let recognizer: SFSpeechRecognizer?
+    private let audioEngine = AVAudioEngine()
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+
+    init(locale: Locale = Locale(identifier: "ja-JP")) {
+        recognizer = SFSpeechRecognizer(locale: locale)
+    }
+
+    /// 音声認識とマイクの権限を要求する。両方許可されれば true。
+    static func requestAuthorization() async -> Bool {
+        let speechStatus: SFSpeechRecognizerAuthorizationStatus = await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status)
+            }
+        }
+        guard speechStatus == .authorized else { return false }
+        return await AVAudioApplication.requestRecordPermission()
+    }
+
+    func startRecording() {
+        stopInternal(cancel: true)
+
+        guard let recognizer, recognizer.isAvailable else {
+            errorMessage = "音声認識が利用できません"
+            return
+        }
+
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.record, mode: .measurement, options: .duckOthers)
+            try session.setActive(true, options: .notifyOthersOnDeactivation)
+
+            let request = SFSpeechAudioBufferRecognitionRequest()
+            request.shouldReportPartialResults = true
+            request.requiresOnDeviceRecognition = recognizer.supportsOnDeviceRecognition
+            self.request = request
+
+            let inputNode = audioEngine.inputNode
+            let format = inputNode.outputFormat(forBus: 0)
+            inputNode.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+                request.append(buffer)
+            }
+
+            audioEngine.prepare()
+            try audioEngine.start()
+
+            transcription = ""
+            isRecording = true
+
+            task = recognizer.recognitionTask(with: request) { [weak self] result, error in
+                guard let self else { return }
+                Task { @MainActor in
+                    if let result {
+                        self.transcription = result.bestTranscription.formattedString
+                    }
+                    if let error {
+                        self.errorMessage = error.localizedDescription
+                        self.stopInternal(cancel: true)
+                    }
+                }
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+            stopInternal(cancel: true)
+        }
+    }
+
+    /// 認識を確定してエンジン停止。transcription は残す。
+    func stopRecording() {
+        stopInternal(cancel: false)
+    }
+
+    /// 認識を破棄してエンジン停止。transcription もクリア。
+    func cancel() {
+        stopInternal(cancel: true)
+        transcription = ""
+    }
+
+    private func stopInternal(cancel: Bool) {
+        if audioEngine.isRunning {
+            audioEngine.stop()
+            audioEngine.inputNode.removeTap(onBus: 0)
+        }
+        request?.endAudio()
+        if cancel {
+            task?.cancel()
+        } else {
+            task?.finish()
+        }
+        request = nil
+        task = nil
+        isRecording = false
+    }
+}

--- a/ios/DailyLog/Views/InProgressCard.swift
+++ b/ios/DailyLog/Views/InProgressCard.swift
@@ -5,6 +5,7 @@ struct InProgressCard: View {
     let onStop: () -> Void
 
     @State private var now: Date = .init()
+    @State private var isPresentingVoiceMemo = false
 
     private let timer = Timer
         .publish(every: 1, on: .main, in: .common)
@@ -25,10 +26,15 @@ struct InProgressCard: View {
                 .fill(Color(.secondarySystemBackground))
         )
         .onReceive(timer) { now = $0 }
+        .sheet(isPresented: $isPresentingVoiceMemo) {
+            if let activity {
+                VoiceMemoSheet(activity: activity)
+            }
+        }
     }
 
     private func activeContent(for activity: Activity) -> some View {
-        HStack(spacing: 14) {
+        HStack(spacing: 12) {
             iconView(for: activity)
 
             VStack(alignment: .leading, spacing: 4) {
@@ -41,16 +47,34 @@ struct InProgressCard: View {
                     .foregroundStyle(.secondary)
             }
 
-            Spacer()
+            Spacer(minLength: 8)
 
-            Button(role: .destructive, action: onStop) {
-                Label("停止", systemImage: "stop.fill")
-                    .labelStyle(.iconOnly)
-                    .font(.title3)
-                    .frame(width: 44, height: 44)
-            }
-            .buttonStyle(.borderedProminent)
+            micButton
+
+            stopButton
         }
+    }
+
+    private var micButton: some View {
+        Button {
+            isPresentingVoiceMemo = true
+        } label: {
+            Image(systemName: "mic")
+                .font(.title3)
+                .frame(width: 44, height: 44)
+        }
+        .buttonStyle(.bordered)
+        .accessibilityLabel("音声メモ")
+    }
+
+    private var stopButton: some View {
+        Button(role: .destructive, action: onStop) {
+            Image(systemName: "stop.fill")
+                .font(.title3)
+                .frame(width: 44, height: 44)
+        }
+        .buttonStyle(.borderedProminent)
+        .accessibilityLabel("停止")
     }
 
     private var emptyContent: some View {

--- a/ios/DailyLog/Views/VoiceMemoSheet.swift
+++ b/ios/DailyLog/Views/VoiceMemoSheet.swift
@@ -1,0 +1,157 @@
+import SwiftUI
+
+struct VoiceMemoSheet: View {
+    let activity: Activity
+
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var recognizer = SpeechRecognitionService()
+    @State private var authorizationStatus: AuthorizationStatus = .checking
+
+    enum AuthorizationStatus {
+        case checking
+        case authorized
+        case denied
+    }
+
+    var body: some View {
+        NavigationStack {
+            content
+                .padding()
+                .navigationTitle("音声メモ")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("キャンセル") {
+                            recognizer.cancel()
+                            dismiss()
+                        }
+                    }
+                }
+                .task {
+                    if await SpeechRecognitionService.requestAuthorization() {
+                        authorizationStatus = .authorized
+                        recognizer.startRecording()
+                    } else {
+                        authorizationStatus = .denied
+                    }
+                }
+                .onDisappear {
+                    recognizer.cancel()
+                }
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch authorizationStatus {
+        case .checking:
+            ProgressView("権限を確認中…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .denied:
+            deniedView
+        case .authorized:
+            authorizedView
+        }
+    }
+
+    private var deniedView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "mic.slash")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text("マイクまたは音声認識の権限がありません")
+                .font(.headline)
+            Text("設定アプリから権限を許可してください。")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var authorizedView: some View {
+        VStack(spacing: 16) {
+            statusIndicator
+
+            transcriptionArea
+
+            actionButtons
+
+            if let message = recognizer.errorMessage {
+                Text(message)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private var statusIndicator: some View {
+        HStack(spacing: 8) {
+            Circle()
+                .fill(recognizer.isRecording ? Color.red : Color.secondary)
+                .frame(width: 10, height: 10)
+                .opacity(recognizer.isRecording ? 1 : 0.4)
+            Text(recognizer.isRecording ? "録音中" : "停止中")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var transcriptionArea: some View {
+        ScrollView {
+            Text(displayText)
+                .font(.body)
+                .foregroundStyle(recognizer.transcription.isEmpty ? .secondary : .primary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+        }
+        .frame(minHeight: 120)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.secondarySystemBackground))
+        )
+    }
+
+    private var displayText: String {
+        recognizer.transcription.isEmpty ? "話しかけてください…" : recognizer.transcription
+    }
+
+    private var actionButtons: some View {
+        HStack(spacing: 12) {
+            if recognizer.isRecording {
+                Button {
+                    recognizer.stopRecording()
+                } label: {
+                    Label("認識を止める", systemImage: "stop.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+            } else {
+                Button {
+                    recognizer.startRecording()
+                } label: {
+                    Label("録音", systemImage: "mic.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+            }
+
+            Button {
+                save()
+            } label: {
+                Label("メモに追加", systemImage: "checkmark")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(recognizer.transcription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        }
+    }
+
+    private func save() {
+        recognizer.stopRecording()
+        activity.appendNote(recognizer.transcription)
+        try? activity.modelContext?.save()
+        dismiss()
+    }
+}

--- a/ios/DailyLogTests/ActivityNoteTests.swift
+++ b/ios/DailyLogTests/ActivityNoteTests.swift
@@ -1,0 +1,37 @@
+@testable import DailyLog
+import XCTest
+
+final class ActivityNoteTests: XCTestCase {
+    func testAppendToEmptyNote() {
+        let activity = Activity()
+        activity.appendNote("こんにちは")
+        XCTAssertEqual(activity.note, "こんにちは")
+    }
+
+    func testAppendSeparatesExistingNoteWithNewline() {
+        let activity = Activity(note: "一言目")
+        activity.appendNote("二言目")
+        XCTAssertEqual(activity.note, "一言目\n二言目")
+    }
+
+    func testAppendTrimsWhitespace() {
+        let activity = Activity(note: "一言目")
+        activity.appendNote("   追加  \n")
+        XCTAssertEqual(activity.note, "一言目\n追加")
+    }
+
+    func testAppendIgnoresEmptyOrWhitespaceOnly() {
+        let activity = Activity(note: "保持される")
+        activity.appendNote("")
+        activity.appendNote("   \n  ")
+        XCTAssertEqual(activity.note, "保持される")
+    }
+
+    func testAppendMultipleEntries() {
+        let activity = Activity()
+        activity.appendNote("a")
+        activity.appendNote("b")
+        activity.appendNote("c")
+        XCTAssertEqual(activity.note, "a\nb\nc")
+    }
+}


### PR DESCRIPTION
## Summary
進行中カードに mic ボタンを追加。音声を SFSpeechRecognizer で認識し、確定で `Activity.note` に追記する。

### コンポーネント
- `Activity.appendNote(_:)` — whitespace トリム、空は無視、既存があれば `\n` 区切りで連結
- `SpeechRecognitionService` (ObservableObject, MainActor)
  - Speech + マイク権限 (`AVAudioApplication.requestRecordPermission()` iOS 17+)
  - `AVAudioEngine` + `SFSpeechAudioBufferRecognitionRequest` でストリーミング認識
  - `requiresOnDeviceRecognition` は端末が対応していれば有効
  - `startRecording` / `stopRecording` (確定) / `cancel` (破棄)
- `VoiceMemoSheet`: checking / denied / authorized の 3 状態、録音中ドット、scrollable transcription、start/stop + 追加ボタン
- `InProgressCard`: 停止ボタンの横に mic ボタン

### Info.plist
`NSMicrophoneUsageDescription` / `NSSpeechRecognitionUsageDescription` は #2 で設定済み

## Tests (+5 / 35 total)
`Activity.appendNote` の純粋ロジック:
- 空メモへの追加 / 既存メモへの追加 (改行区切り)
- 前後空白のトリム
- 空文字列・空白のみの入力は無視
- 複数回追加

SFSpeechRecognizer 本体は mic と権限を必要とするため unit test 対象外。手動検証で担保。

## Verification (local)
- [x] `swiftformat --lint` / `swiftlint --strict` clean
- [x] `make -C ios build` SUCCEEDED
- [x] `make -C ios test` 35/35 passed

Closes #11