### PR TITLE
TASK-12: 食事記録 (写真 + 店舗情報)

### DIFF
--- a/ios/DailyLog/Extensions/Activity+Meal.swift
+++ b/ios/DailyLog/Extensions/Activity+Meal.swift
@@ -1,0 +1,17 @@
+import Foundation
+import SwiftData
+
+extension Activity {
+    /// 食事タイプの Activity に対して Meal を確実に存在させる。
+    /// 既存の Meal があればそれを返す。
+    @discardableResult
+    func ensureMeal(in context: ModelContext) -> Meal {
+        if let meal {
+            return meal
+        }
+        let new = Meal(activity: self)
+        context.insert(new)
+        meal = new
+        return new
+    }
+}

--- a/ios/DailyLog/Models/Meal.swift
+++ b/ios/DailyLog/Models/Meal.swift
@@ -4,7 +4,7 @@ import SwiftData
 @Model
 final class Meal {
     var id: UUID = UUID()
-    var photoFilename: String?
+    var photoFilenames: [String] = []
     var shopName: String?
     var shopAddress: String?
     var note: String = ""
@@ -15,7 +15,7 @@ final class Meal {
     init(
         id: UUID = UUID(),
         activity: Activity? = nil,
-        photoFilename: String? = nil,
+        photoFilenames: [String] = [],
         shopName: String? = nil,
         shopAddress: String? = nil,
         note: String = "",
@@ -23,7 +23,7 @@ final class Meal {
     ) {
         self.id = id
         self.activity = activity
-        self.photoFilename = photoFilename
+        self.photoFilenames = photoFilenames
         self.shopName = shopName
         self.shopAddress = shopAddress
         self.note = note

--- a/ios/DailyLog/Services/PhotoStorage.swift
+++ b/ios/DailyLog/Services/PhotoStorage.swift
@@ -1,0 +1,66 @@
+import Foundation
+import UIKit
+
+/// 食事写真などを App Group 共有コンテナに保存する。
+///
+/// 本体アプリと `DailyLogWidget` で同じ領域を参照できる。
+struct PhotoStorage {
+    static let appGroupIdentifier = "group.com.coco.daily-log"
+
+    let rootURL: URL
+
+    /// App Group コンテナの Photos ディレクトリを使う本番用インスタンス。
+    /// 取得できない場合 (エンタイトルメント不備など) は `nil`。
+    static func makeDefault() -> PhotoStorage? {
+        guard let container = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: appGroupIdentifier
+        ) else {
+            return nil
+        }
+        return PhotoStorage(rootURL: container.appendingPathComponent("Photos", isDirectory: true))
+    }
+
+    /// JPEG バイト列を保存し、生成したファイル名を返す。
+    func saveJPEG(_ data: Data) throws -> String {
+        try FileManager.default.createDirectory(
+            at: rootURL,
+            withIntermediateDirectories: true
+        )
+        let filename = "\(UUID().uuidString).jpg"
+        let url = rootURL.appendingPathComponent(filename)
+        try data.write(to: url, options: .atomic)
+        return filename
+    }
+
+    /// UIImage を JPEG 圧縮 (80%) して保存する。
+    func save(_ image: UIImage) throws -> String {
+        guard let data = image.jpegData(compressionQuality: 0.8) else {
+            throw PhotoStorageError.encodingFailed
+        }
+        return try saveJPEG(data)
+    }
+
+    func url(for filename: String) -> URL {
+        rootURL.appendingPathComponent(filename)
+    }
+
+    func loadData(filename: String) -> Data? {
+        try? Data(contentsOf: url(for: filename))
+    }
+
+    func loadImage(filename: String) -> UIImage? {
+        guard let data = loadData(filename: filename) else { return nil }
+        return UIImage(data: data)
+    }
+
+    func delete(filename: String) throws {
+        let target = url(for: filename)
+        if FileManager.default.fileExists(atPath: target.path) {
+            try FileManager.default.removeItem(at: target)
+        }
+    }
+
+    enum PhotoStorageError: Error {
+        case encodingFailed
+    }
+}

--- a/ios/DailyLog/Views/InProgressCard.swift
+++ b/ios/DailyLog/Views/InProgressCard.swift
@@ -6,6 +6,7 @@ struct InProgressCard: View {
 
     @State private var now: Date = .init()
     @State private var isPresentingVoiceMemo = false
+    @State private var isPresentingMeal = false
 
     private let timer = Timer
         .publish(every: 1, on: .main, in: .common)
@@ -31,6 +32,11 @@ struct InProgressCard: View {
                 VoiceMemoSheet(activity: activity)
             }
         }
+        .sheet(isPresented: $isPresentingMeal) {
+            if let activity {
+                MealDetailView(activity: activity)
+            }
+        }
     }
 
     private func activeContent(for activity: Activity) -> some View {
@@ -49,10 +55,26 @@ struct InProgressCard: View {
 
             Spacer(minLength: 8)
 
+            if activity.template?.isMealType == true {
+                mealButton
+            }
+
             micButton
 
             stopButton
         }
+    }
+
+    private var mealButton: some View {
+        Button {
+            isPresentingMeal = true
+        } label: {
+            Image(systemName: "fork.knife")
+                .font(.title3)
+                .frame(width: 44, height: 44)
+        }
+        .buttonStyle(.bordered)
+        .accessibilityLabel("食事の記録")
     }
 
     private var micButton: some View {

--- a/ios/DailyLog/Views/Meal/CameraPicker.swift
+++ b/ios/DailyLog/Views/Meal/CameraPicker.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+import UIKit
+
+struct CameraPicker: UIViewControllerRepresentable {
+    let onPicked: (UIImage) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.cameraCaptureMode = .photo
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onPicked: onPicked, dismiss: { dismiss() })
+    }
+
+    final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        let onPicked: (UIImage) -> Void
+        let dismiss: () -> Void
+
+        init(onPicked: @escaping (UIImage) -> Void, dismiss: @escaping () -> Void) {
+            self.onPicked = onPicked
+            self.dismiss = dismiss
+        }
+
+        func imagePickerController(
+            _ picker: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
+            if let image = info[.originalImage] as? UIImage {
+                onPicked(image)
+            }
+            dismiss()
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            dismiss()
+        }
+    }
+
+    static var isCameraAvailable: Bool {
+        UIImagePickerController.isSourceTypeAvailable(.camera)
+    }
+}

--- a/ios/DailyLog/Views/Meal/MealDetailView.swift
+++ b/ios/DailyLog/Views/Meal/MealDetailView.swift
@@ -1,0 +1,174 @@
+import PhotosUI
+import SwiftData
+import SwiftUI
+
+struct MealDetailView: View {
+    let activity: Activity
+
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var shopName: String = ""
+    @State private var shopAddress: String = ""
+    @State private var note: String = ""
+    @State private var photoFilenames: [String] = []
+    @State private var photoSelection: [PhotosPickerItem] = []
+    @State private var isPresentingCamera = false
+    @State private var isPresentingSourceDialog = false
+    @State private var errorMessage: String?
+
+    private let storage: PhotoStorage? = PhotoStorage.makeDefault()
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                photosSection
+                shopSection
+                noteSection
+            }
+            .navigationTitle("食事の記録")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("キャンセル") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("保存") { save() }
+                }
+            }
+            .confirmationDialog("写真を追加", isPresented: $isPresentingSourceDialog) {
+                if CameraPicker.isCameraAvailable {
+                    Button("カメラで撮影") { isPresentingCamera = true }
+                }
+                photosPickerButton
+            }
+            .fullScreenCover(isPresented: $isPresentingCamera) {
+                CameraPicker { image in
+                    handlePickedImage(image)
+                }
+            }
+            .onChange(of: photoSelection) { _, new in
+                Task { await handlePhotosPickerSelection(new) }
+            }
+            .onAppear(perform: loadFromActivity)
+            .alert(
+                "エラー",
+                isPresented: Binding(
+                    get: { errorMessage != nil },
+                    set: { if !$0 { errorMessage = nil } }
+                ),
+                presenting: errorMessage
+            ) { _ in
+                Button("OK", role: .cancel) { errorMessage = nil }
+            } message: { message in
+                Text(message)
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var photosSection: some View {
+        Section("写真") {
+            if photoFilenames.isEmpty {
+                Text("まだ写真がありません")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } else if let storage {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 10) {
+                        ForEach(photoFilenames, id: \.self) { filename in
+                            MealPhotoThumbnail(
+                                filename: filename,
+                                storage: storage,
+                                onDelete: { removePhoto(filename: filename) }
+                            )
+                        }
+                    }
+                }
+            }
+
+            Button {
+                isPresentingSourceDialog = true
+            } label: {
+                Label("写真を追加", systemImage: "plus")
+            }
+        }
+    }
+
+    private var shopSection: some View {
+        Section("店舗 (任意)") {
+            TextField("店舗名", text: $shopName)
+            TextField("住所", text: $shopAddress)
+        }
+    }
+
+    private var noteSection: some View {
+        Section("メモ (任意)") {
+            TextField("内容・感想など", text: $note, axis: .vertical)
+                .lineLimit(3 ... 6)
+        }
+    }
+
+    private var photosPickerButton: some View {
+        PhotosPicker(
+            selection: $photoSelection,
+            maxSelectionCount: 4,
+            matching: .images
+        ) {
+            Text("ライブラリから選択")
+        }
+    }
+
+    // MARK: - Actions
+
+    private func loadFromActivity() {
+        let meal = activity.ensureMeal(in: modelContext)
+        shopName = meal.shopName ?? ""
+        shopAddress = meal.shopAddress ?? ""
+        note = meal.note
+        photoFilenames = meal.photoFilenames
+    }
+
+    private func handlePickedImage(_ image: UIImage) {
+        guard let storage else {
+            errorMessage = "App Group の写真保存領域が使えません (エンタイトルメントを確認してください)"
+            return
+        }
+        do {
+            let filename = try storage.save(image)
+            photoFilenames.append(filename)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func handlePhotosPickerSelection(_ items: [PhotosPickerItem]) async {
+        guard !items.isEmpty else { return }
+        defer { photoSelection = [] }
+        for item in items {
+            guard let data = try? await item.loadTransferable(type: Data.self) else { continue }
+            guard let image = UIImage(data: data) else { continue }
+            handlePickedImage(image)
+        }
+    }
+
+    private func removePhoto(filename: String) {
+        photoFilenames.removeAll { $0 == filename }
+        try? storage?.delete(filename: filename)
+    }
+
+    private func save() {
+        let meal = activity.ensureMeal(in: modelContext)
+        meal.shopName = shopName.isEmpty ? nil : shopName
+        meal.shopAddress = shopAddress.isEmpty ? nil : shopAddress
+        meal.note = note
+        meal.photoFilenames = photoFilenames
+        do {
+            try modelContext.save()
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/ios/DailyLog/Views/Meal/MealPhotoThumbnail.swift
+++ b/ios/DailyLog/Views/Meal/MealPhotoThumbnail.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct MealPhotoThumbnail: View {
+    let filename: String
+    let storage: PhotoStorage
+    let onDelete: () -> Void
+
+    @State private var image: UIImage?
+
+    private let side: CGFloat = 90
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            photoArea
+
+            Button(action: onDelete) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title3)
+                    .foregroundStyle(.white, .black.opacity(0.6))
+            }
+            .padding(4)
+            .accessibilityLabel("写真を削除")
+        }
+        .frame(width: side, height: side)
+        .task {
+            image = storage.loadImage(filename: filename)
+        }
+    }
+
+    @ViewBuilder
+    private var photoArea: some View {
+        if let image {
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFill()
+                .frame(width: side, height: side)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+        } else {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color(.secondarySystemBackground))
+                .overlay(
+                    ProgressView()
+                )
+                .frame(width: side, height: side)
+        }
+    }
+}

--- a/ios/DailyLogTests/PhotoStorageTests.swift
+++ b/ios/DailyLogTests/PhotoStorageTests.swift
@@ -1,0 +1,65 @@
+@testable import DailyLog
+import UIKit
+import XCTest
+
+final class PhotoStorageTests: XCTestCase {
+    private var tempDirectory: URL!
+    private var storage: PhotoStorage!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PhotoStorageTests-\(UUID().uuidString)", isDirectory: true)
+        storage = PhotoStorage(rootURL: tempDirectory)
+    }
+
+    override func tearDownWithError() throws {
+        if let url = tempDirectory {
+            try? FileManager.default.removeItem(at: url)
+        }
+        storage = nil
+        tempDirectory = nil
+        try super.tearDownWithError()
+    }
+
+    func testSaveAndLoadJPEG() throws {
+        let image = makeSolidImage(color: .red)
+        let filename = try storage.save(image)
+
+        XCTAssertTrue(filename.hasSuffix(".jpg"))
+        let loaded = try XCTUnwrap(storage.loadImage(filename: filename))
+        XCTAssertGreaterThan(loaded.size.width, 0)
+        XCTAssertGreaterThan(loaded.size.height, 0)
+    }
+
+    func testSaveJPEGData() throws {
+        let image = makeSolidImage(color: .blue)
+        let data = try XCTUnwrap(image.jpegData(compressionQuality: 0.8))
+        let filename = try storage.saveJPEG(data)
+
+        let reloaded = try XCTUnwrap(storage.loadData(filename: filename))
+        XCTAssertEqual(reloaded.count, data.count)
+    }
+
+    func testDeleteRemovesFile() throws {
+        let image = makeSolidImage(color: .green)
+        let filename = try storage.save(image)
+        XCTAssertNotNil(storage.loadImage(filename: filename))
+
+        try storage.delete(filename: filename)
+
+        XCTAssertNil(storage.loadImage(filename: filename))
+    }
+
+    func testDeleteMissingIsNoOp() {
+        XCTAssertNoThrow(try storage.delete(filename: "does-not-exist.jpg"))
+    }
+
+    private func makeSolidImage(color: UIColor, size: CGSize = CGSize(width: 40, height: 40)) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { context in
+            color.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
食事タイプのテンプレで進行中の場合、進行中カードに `fork.knife` ボタンを表示、食事詳細シートで写真と店舗情報を編集できるようにする。

### モデル変更
- `Meal.photoFilename: String?` を削除し `photoFilenames: [String] = []` に変更
- CloudKit 互換性 (default 値、`.unique` なし) を維持

### 写真ストレージ
- `PhotoStorage` struct で rootURL を保持
  - `makeDefault()` は App Group コンテナの Photos ディレクトリを返す (エンタイトルメント未設定時は nil)
  - `save(UIImage)` → JPEG 80% で `<UUID>.jpg` 保存
  - `loadImage` / `loadData` / `delete` / `url(for:)`
- エンタイトルメント未設定時の fallback としてエラー表示

### UI
- `CameraPicker`: `UIImagePickerController(.camera)` の SwiftUI ラッパー
- `MealPhotoThumbnail`: 90pt 正方形、ロードは `.task` 遅延、削除ボタン overlay
- `MealDetailView`: Form (写真横スクロール + 追加ボタン / 店舗 / メモ)。追加はカメラ or PhotosPicker (最大 4) を confirmationDialog で選択
- `InProgressCard`: `template.isMealType == true` のとき mealButton 表示

## Tests (+5 / 40 total)
- `PhotoStorage.save` UIImage round-trip
- `saveJPEG(Data)` round-trip
- `delete` でファイル消去
- `delete` 存在しないファイルは no-op
- 一時ディレクトリで実行、App Group 不要

## Verification (local)
- [x] `swiftformat --lint` / `swiftlint --strict` clean
- [x] `make -C ios build` SUCCEEDED
- [x] `make -C ios test` 40/40 passed

## Notes
- カメラ実機確認は必須 (simulator だとソースが無い)
- App Group の実パス動作確認は #24 の Apple Dev Portal 設定完了後
- Core ML 自動カロリー計算は #13 で別途

Closes #12
Refs #13 #24