### PR TITLE
TASK-14: カレンダー表示 (UICalendarView + 日別詳細)

### DIFF
--- a/ios/DailyLog/DailyLogApp.swift
+++ b/ios/DailyLog/DailyLogApp.swift
@@ -15,7 +15,7 @@ struct DailyLogApp: App {
 
     var body: some Scene {
         WindowGroup {
-            HomeView()
+            MainTabView()
         }
         .modelContainer(modelContainer)
     }

--- a/ios/DailyLog/Utilities/ActivityDateExtractor.swift
+++ b/ios/DailyLog/Utilities/ActivityDateExtractor.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// 記録済み Activity から「年月日」単位の `DateComponents` 集合を作る。
+/// UICalendarView の decoration 表示や day-view の検索に使う。
+enum ActivityDateExtractor {
+    static func extractDateComponents(
+        from activities: [Activity],
+        calendar: Calendar = Calendar(identifier: .gregorian)
+    ) -> Set<DateComponents> {
+        var calendar = calendar
+        calendar.timeZone = .current
+        let components = activities.map { activity in
+            calendar.dateComponents([.year, .month, .day], from: activity.startAt)
+        }
+        return Set(components)
+    }
+
+    static func activities(
+        on day: Date,
+        from activities: [Activity],
+        calendar: Calendar = Calendar(identifier: .gregorian)
+    ) -> [Activity] {
+        var calendar = calendar
+        calendar.timeZone = .current
+        let target = calendar.dateComponents([.year, .month, .day], from: day)
+        return activities.filter { activity in
+            let candidate = calendar.dateComponents([.year, .month, .day], from: activity.startAt)
+            return candidate == target
+        }
+    }
+}

--- a/ios/DailyLog/Utilities/ActivityDateExtractor.swift
+++ b/ios/DailyLog/Utilities/ActivityDateExtractor.swift
@@ -5,10 +5,8 @@ import Foundation
 enum ActivityDateExtractor {
     static func extractDateComponents(
         from activities: [Activity],
-        calendar: Calendar = Calendar(identifier: .gregorian)
+        calendar: Calendar = .currentGregorian
     ) -> Set<DateComponents> {
-        var calendar = calendar
-        calendar.timeZone = .current
         let components = activities.map { activity in
             calendar.dateComponents([.year, .month, .day], from: activity.startAt)
         }
@@ -18,14 +16,21 @@ enum ActivityDateExtractor {
     static func activities(
         on day: Date,
         from activities: [Activity],
-        calendar: Calendar = Calendar(identifier: .gregorian)
+        calendar: Calendar = .currentGregorian
     ) -> [Activity] {
-        var calendar = calendar
-        calendar.timeZone = .current
         let target = calendar.dateComponents([.year, .month, .day], from: day)
         return activities.filter { activity in
             let candidate = calendar.dateComponents([.year, .month, .day], from: activity.startAt)
             return candidate == target
         }
+    }
+}
+
+extension Calendar {
+    /// 端末のタイムゾーンに従うグレゴリオ暦。ホーム/カレンダー表示で使う既定値。
+    static var currentGregorian: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .current
+        return calendar
     }
 }

--- a/ios/DailyLog/Views/Calendar/ActivityCalendar.swift
+++ b/ios/DailyLog/Views/Calendar/ActivityCalendar.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import UIKit
+
+/// `UICalendarView` の SwiftUI ラッパー。
+///
+/// - `datesWithActivity` に含まれる日にデコレーションを表示する
+/// - 日付を選択すると `selectedDate` が更新される
+struct ActivityCalendar: UIViewRepresentable {
+    @Binding var selectedDate: Date?
+    let datesWithActivity: Set<DateComponents>
+
+    func makeUIView(context: Context) -> UICalendarView {
+        let view = UICalendarView()
+        view.calendar = Calendar(identifier: .gregorian)
+        view.locale = Locale.current
+        view.delegate = context.coordinator
+        let selection = UICalendarSelectionSingleDate(delegate: context.coordinator)
+        view.selectionBehavior = selection
+        return view
+    }
+
+    func updateUIView(_ uiView: UICalendarView, context: Context) {
+        let previousDates = context.coordinator.datesWithActivity
+        context.coordinator.datesWithActivity = datesWithActivity
+        let changed = previousDates.symmetricDifference(datesWithActivity)
+        if !changed.isEmpty {
+            uiView.reloadDecorations(forDateComponents: Array(changed), animated: true)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(
+            datesWithActivity: datesWithActivity,
+            onSelect: { selectedDate = $0 }
+        )
+    }
+
+    final class Coordinator: NSObject, UICalendarViewDelegate, UICalendarSelectionSingleDateDelegate {
+        var datesWithActivity: Set<DateComponents>
+        let onSelect: (Date?) -> Void
+
+        init(datesWithActivity: Set<DateComponents>, onSelect: @escaping (Date?) -> Void) {
+            self.datesWithActivity = datesWithActivity
+            self.onSelect = onSelect
+        }
+
+        func calendarView(
+            _ calendarView: UICalendarView,
+            decorationFor dateComponents: DateComponents
+        ) -> UICalendarView.Decoration? {
+            let ymd = DateComponents(
+                year: dateComponents.year,
+                month: dateComponents.month,
+                day: dateComponents.day
+            )
+            guard datesWithActivity.contains(ymd) else { return nil }
+            return .default(color: .systemBlue, size: .medium)
+        }
+
+        func dateSelection(
+            _ selection: UICalendarSelectionSingleDate,
+            didSelectDate dateComponents: DateComponents?
+        ) {
+            guard let dateComponents else {
+                onSelect(nil)
+                return
+            }
+            var calendar = Calendar(identifier: .gregorian)
+            calendar.timeZone = .current
+            onSelect(calendar.date(from: dateComponents))
+        }
+    }
+}

--- a/ios/DailyLog/Views/Calendar/CalendarView.swift
+++ b/ios/DailyLog/Views/Calendar/CalendarView.swift
@@ -1,0 +1,75 @@
+import SwiftData
+import SwiftUI
+
+struct CalendarView: View {
+    @Query(sort: \Activity.startAt)
+    private var activities: [Activity]
+
+    @State private var selectedDate: Date?
+
+    private var datesWithActivity: Set<DateComponents> {
+        ActivityDateExtractor.extractDateComponents(from: activities)
+    }
+
+    private var activitiesOnSelectedDay: [Activity] {
+        guard let selectedDate else { return [] }
+        return ActivityDateExtractor.activities(on: selectedDate, from: activities)
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    ActivityCalendar(
+                        selectedDate: $selectedDate,
+                        datesWithActivity: datesWithActivity
+                    )
+                    .frame(minHeight: 360)
+
+                    selectedDaySummary
+                }
+                .padding()
+            }
+            .navigationTitle("カレンダー")
+            .navigationDestination(item: $selectedDate) { date in
+                DayDetailView(date: date)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var selectedDaySummary: some View {
+        if let selectedDate {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(formatted(date: selectedDate))
+                    .font(.headline)
+
+                if activitiesOnSelectedDay.isEmpty {
+                    Text("この日の記録はありません")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("\(activitiesOnSelectedDay.count) 件の記録")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
+                    NavigationLink(value: selectedDate) {
+                        Label("この日の詳細を見る", systemImage: "chart.pie")
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+        } else {
+            Text("日付を選択してください")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func formatted(date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.dateStyle = .long
+        return formatter.string(from: date)
+    }
+}

--- a/ios/DailyLog/Views/Calendar/DayDetailView.swift
+++ b/ios/DailyLog/Views/Calendar/DayDetailView.swift
@@ -1,0 +1,116 @@
+import SwiftData
+import SwiftUI
+
+/// カレンダーから日付をタップしたときに開く 1 日の詳細画面。
+/// 円グラフは #16 で本実装する (ここでは一覧表示のみ)。
+struct DayDetailView: View {
+    let date: Date
+
+    @Query(sort: \Activity.startAt)
+    private var allActivities: [Activity]
+
+    private var activities: [Activity] {
+        ActivityDateExtractor.activities(on: date, from: allActivities)
+    }
+
+    var body: some View {
+        List {
+            Section("サマリー") {
+                LabeledContent("記録数", value: "\(activities.count)")
+                LabeledContent("合計時間", value: totalDurationText)
+            }
+
+            Section("記録") {
+                if activities.isEmpty {
+                    Text("この日の記録はありません")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(activities) { activity in
+                        DayActivityRow(activity: activity)
+                    }
+                }
+            }
+
+            Section {
+                Text("円グラフは今後 Issue #16 で実装予定")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .navigationTitle(titleText)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var titleText: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.dateStyle = .medium
+        return formatter.string(from: date)
+    }
+
+    private var totalDurationText: String {
+        let seconds = activities.reduce(0) { running, activity in
+            running + Int(activity.duration ?? 0)
+        }
+        return DurationFormatter.elapsed(seconds: seconds)
+    }
+}
+
+private struct DayActivityRow: View {
+    let activity: Activity
+
+    var body: some View {
+        HStack(spacing: 12) {
+            iconView
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(activity.template?.name ?? "（テンプレートなし）")
+                    .font(.body)
+                Text(timeRangeText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if let duration = activity.duration {
+                Text(DurationFormatter.elapsed(seconds: Int(duration)))
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("進行中")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var iconView: some View {
+        if let template = activity.template {
+            Image(systemName: template.iconName)
+                .font(.callout)
+                .foregroundStyle(.white)
+                .frame(width: 28, height: 28)
+                .background(
+                    Circle()
+                        .fill(Color(hex: template.colorHex) ?? .accentColor)
+                )
+        } else {
+            Circle()
+                .fill(Color.secondary)
+                .frame(width: 28, height: 28)
+        }
+    }
+
+    private var timeRangeText: String {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        let start = formatter.string(from: activity.startAt)
+        if let end = activity.endAt {
+            return "\(start) - \(formatter.string(from: end))"
+        } else {
+            return "\(start) -"
+        }
+    }
+}

--- a/ios/DailyLog/Views/MainTabView.swift
+++ b/ios/DailyLog/Views/MainTabView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct MainTabView: View {
+    var body: some View {
+        TabView {
+            HomeView()
+                .tabItem {
+                    Label("ホーム", systemImage: "clock")
+                }
+
+            CalendarView()
+                .tabItem {
+                    Label("カレンダー", systemImage: "calendar")
+                }
+        }
+    }
+}

--- a/ios/DailyLogTests/ActivityDateExtractorTests.swift
+++ b/ios/DailyLogTests/ActivityDateExtractorTests.swift
@@ -1,0 +1,56 @@
+@testable import DailyLog
+import XCTest
+
+final class ActivityDateExtractorTests: XCTestCase {
+    private let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Tokyo") ?? .current
+        return calendar
+    }()
+
+    func testExtractsUniqueYearMonthDayComponents() {
+        let activities = [
+            makeActivity(on: date(2026, 4, 25, hour: 9)),
+            makeActivity(on: date(2026, 4, 25, hour: 15)),
+            makeActivity(on: date(2026, 4, 26, hour: 7)),
+        ]
+
+        let result = ActivityDateExtractor.extractDateComponents(from: activities, calendar: calendar)
+
+        let expected: Set<DateComponents> = [
+            DateComponents(year: 2026, month: 4, day: 25),
+            DateComponents(year: 2026, month: 4, day: 26),
+        ]
+        XCTAssertEqual(result, expected)
+    }
+
+    func testFiltersActivitiesByCalendarDay() {
+        let morning = makeActivity(on: date(2026, 4, 25, hour: 8))
+        let evening = makeActivity(on: date(2026, 4, 25, hour: 22))
+        let nextDay = makeActivity(on: date(2026, 4, 26, hour: 1))
+
+        let result = ActivityDateExtractor.activities(
+            on: date(2026, 4, 25, hour: 12),
+            from: [morning, evening, nextDay],
+            calendar: calendar
+        )
+
+        XCTAssertEqual(Set(result.map(\.id)), Set([morning.id, evening.id]))
+    }
+
+    // MARK: - Helpers
+
+    private func date(_ year: Int, _ month: Int, _ day: Int, hour: Int = 0) -> Date {
+        let components = DateComponents(
+            year: year,
+            month: month,
+            day: day,
+            hour: hour
+        )
+        return calendar.date(from: components) ?? Date()
+    }
+
+    private func makeActivity(on date: Date) -> Activity {
+        Activity(startAt: date, endAt: date.addingTimeInterval(3600))
+    }
+}

--- a/ios/DailyLogTests/ActivityDateExtractorTests.swift
+++ b/ios/DailyLogTests/ActivityDateExtractorTests.swift
@@ -17,11 +17,12 @@ final class ActivityDateExtractorTests: XCTestCase {
 
         let result = ActivityDateExtractor.extractDateComponents(from: activities, calendar: calendar)
 
-        let expected: Set<DateComponents> = [
-            DateComponents(year: 2026, month: 4, day: 25),
-            DateComponents(year: 2026, month: 4, day: 26),
-        ]
-        XCTAssertEqual(result, expected)
+        // Calendar.dateComponents(_:from:) can populate extra fields (e.g. isLeapMonth)
+        // that vary between SDK versions, so compare only the identity triple.
+        let keys = Set(result.map { components -> String in
+            "\(components.year ?? 0)-\(components.month ?? 0)-\(components.day ?? 0)"
+        })
+        XCTAssertEqual(keys, Set(["2026-4-25", "2026-4-26"]))
     }
 
     func testFiltersActivitiesByCalendarDay() {


### PR DESCRIPTION
## Summary
記録のある日がデコレーションされたカレンダー画面を追加。日付タップで 1 日の詳細 (記録一覧) に遷移。

### 新 UI
- **MainTabView**: TabView でホーム + カレンダーに。`DailyLogApp` のエントリを変更
- **ActivityCalendar**: UICalendarView の UIViewRepresentable
  - `datesWithActivity: Set<DateComponents>` の差分だけ `reloadDecorations` して全月リロードを避ける
  - 青の medium ドットで記録のある日を示す
  - `UICalendarSelectionSingleDate` で日付タップ検出
- **CalendarView**: カレンダー + 選択日のサマリー + 詳細遷移リンク
- **DayDetailView**: 1 日の記録一覧 (時間範囲 / 所要 / 進行中マーカー)。円グラフは #16 で実装

### データ補助
- `ActivityDateExtractor.extractDateComponents(from:)` — `[Activity]` → 年月日の `Set<DateComponents>`
- `activities(on:)` — 指定日の Activity を取り出す
- Calendar/timezone を注入可能にしてテストを決定的に

## Tests (+2 / 42 total)
- `extractDateComponents`: 同日複数 Activity は 1 件に dedupe、別日は別個
- `activities(on:)`: 日付単位の filter (Asia/Tokyo 固定)

## Verification (local)
- [x] `swiftformat --lint` / `swiftlint --strict` clean
- [x] `make -C ios build` SUCCEEDED
- [x] `make -C ios test` 42/42 passed

Closes #14
Refs #15 #16 #17