### PR TITLE
TASK-15: 週 24 時間チャート (Swift Charts)

### DIFF
--- a/ios/DailyLog/Utilities/WeekActivityLayout.swift
+++ b/ios/DailyLog/Utilities/WeekActivityLayout.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// 週ビューのチャート用に `Activity` を曜日 × 時間帯の区間に変換する。
+enum WeekActivityLayout {
+    struct Span: Identifiable, Equatable {
+        let id: UUID
+        let activityID: UUID
+        let weekdayIndex: Int // 0 = 週頭の曜日 から 6 = 週末
+        let startHours: Double // 0.0 ... 24.0
+        let endHours: Double // startHours < endHours ≤ 24.0
+        let colorHex: String
+        let templateName: String
+    }
+
+    /// 指定週内の Activity を Span 配列に変換する。
+    /// 日をまたぐ Activity は 1 日ごとに分割する。
+    /// 進行中 (`endAt == nil`) は `now` で切ってそこまでを表示。
+    static func spans(
+        for activities: [Activity],
+        weekStart: Date,
+        calendar: Calendar = .currentGregorian,
+        now: Date = Date()
+    ) -> [Span] {
+        let weekEnd = calendar.date(byAdding: .day, value: 7, to: weekStart) ?? weekStart
+        var spans: [Span] = []
+
+        for activity in activities {
+            let effectiveEnd = activity.endAt ?? now
+            // 週外は除外
+            guard activity.startAt < weekEnd, effectiveEnd > weekStart else { continue }
+
+            let clippedStart = max(activity.startAt, weekStart)
+            let clippedEnd = min(effectiveEnd, weekEnd)
+            guard clippedEnd > clippedStart else { continue }
+
+            var cursor = clippedStart
+            while cursor < clippedEnd {
+                let dayStart = calendar.startOfDay(for: cursor)
+                guard let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) else { break }
+                let chunkEnd = min(clippedEnd, dayEnd)
+
+                let weekdayIndex = Int(
+                    (cursor.timeIntervalSince(weekStart) / 86400).rounded(.down)
+                )
+                guard weekdayIndex >= 0, weekdayIndex < 7 else {
+                    cursor = dayEnd
+                    continue
+                }
+
+                let startHours = hours(from: dayStart, to: cursor)
+                let endHours = hours(from: dayStart, to: chunkEnd)
+
+                spans.append(
+                    Span(
+                        id: UUID(),
+                        activityID: activity.id,
+                        weekdayIndex: weekdayIndex,
+                        startHours: startHours,
+                        endHours: endHours,
+                        colorHex: activity.template?.colorHex ?? "#7F8C8D",
+                        templateName: activity.template?.name ?? "—"
+                    )
+                )
+
+                cursor = chunkEnd
+            }
+        }
+
+        return spans
+    }
+
+    /// 指定日が属する週の先頭日 (00:00) を返す。
+    /// カレンダーの `firstWeekday` に従う (日本は日曜始まり、ドイツは月曜始まり)。
+    static func weekStart(
+        containing date: Date,
+        calendar: Calendar = .currentGregorian
+    ) -> Date {
+        let weekday = calendar.component(.weekday, from: date)
+        let offset = (weekday - calendar.firstWeekday + 7) % 7
+        let dayStart = calendar.startOfDay(for: date)
+        return calendar.date(byAdding: .day, value: -offset, to: dayStart) ?? dayStart
+    }
+
+    private static func hours(from start: Date, to end: Date) -> Double {
+        end.timeIntervalSince(start) / 3600
+    }
+}

--- a/ios/DailyLog/Views/MainTabView.swift
+++ b/ios/DailyLog/Views/MainTabView.swift
@@ -12,6 +12,11 @@ struct MainTabView: View {
                 .tabItem {
                     Label("カレンダー", systemImage: "calendar")
                 }
+
+            StatsView()
+                .tabItem {
+                    Label("統計", systemImage: "chart.bar")
+                }
         }
     }
 }

--- a/ios/DailyLog/Views/Stats/StatsView.swift
+++ b/ios/DailyLog/Views/Stats/StatsView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct StatsView: View {
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("チャート") {
+                    NavigationLink("週 24 時間チャート") {
+                        WeekChartView()
+                    }
+                    // #16 日別円グラフ / #17 週月統計 は追って追加
+                }
+            }
+            .navigationTitle("統計")
+        }
+    }
+}

--- a/ios/DailyLog/Views/Stats/WeekActivityChart.swift
+++ b/ios/DailyLog/Views/Stats/WeekActivityChart.swift
@@ -1,0 +1,60 @@
+import Charts
+import SwiftUI
+
+struct WeekActivityChart: View {
+    let weekStart: Date
+    let spans: [WeekActivityLayout.Span]
+    let weekdayLabels: [String]
+
+    var body: some View {
+        Chart {
+            ForEach(spans) { span in
+                RectangleMark(
+                    xStart: .value("start-day", Double(span.weekdayIndex) - 0.4),
+                    xEnd: .value("end-day", Double(span.weekdayIndex) + 0.4),
+                    yStart: .value("start-hour", span.startHours),
+                    yEnd: .value("end-hour", span.endHours)
+                )
+                .foregroundStyle(Color(hex: span.colorHex) ?? .accentColor)
+                .opacity(0.85)
+            }
+        }
+        .chartXScale(domain: -0.5 ... 6.5)
+        .chartYScale(domain: 0.0 ... 24.0)
+        .chartXAxis {
+            AxisMarks(values: Array(0 ..< 7).map(Double.init)) { value in
+                AxisValueLabel { weekdayLabel(for: value) }
+            }
+        }
+        .chartYAxis {
+            AxisMarks(values: [0.0, 6.0, 12.0, 18.0, 24.0]) { value in
+                AxisGridLine()
+                AxisTick()
+                AxisValueLabel {
+                    if let hour = value.as(Double.self) {
+                        Text(String(format: "%02d:00", Int(hour)))
+                            .font(.caption2)
+                    }
+                }
+            }
+        }
+        .chartPlotStyle { plot in
+            plot
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color(.secondarySystemBackground))
+                )
+        }
+    }
+
+    @ViewBuilder
+    private func weekdayLabel(for value: AxisValue) -> some View {
+        if let raw = value.as(Double.self) {
+            let idx = Int(raw)
+            if idx >= 0, idx < weekdayLabels.count {
+                Text(weekdayLabels[idx])
+                    .font(.caption)
+            }
+        }
+    }
+}

--- a/ios/DailyLog/Views/Stats/WeekChartView.swift
+++ b/ios/DailyLog/Views/Stats/WeekChartView.swift
@@ -1,0 +1,98 @@
+import SwiftData
+import SwiftUI
+
+struct WeekChartView: View {
+    @Query(sort: \Activity.startAt)
+    private var allActivities: [Activity]
+
+    @State private var weekStart: Date = WeekActivityLayout.weekStart(containing: Date())
+
+    private let calendar: Calendar = .currentGregorian
+
+    private var weekEnd: Date {
+        calendar.date(byAdding: .day, value: 7, to: weekStart) ?? weekStart
+    }
+
+    private var spans: [WeekActivityLayout.Span] {
+        WeekActivityLayout.spans(for: allActivities, weekStart: weekStart, calendar: calendar)
+    }
+
+    private var weekdayLabels: [String] {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.dateFormat = "E"
+        return (0 ..< 7).compactMap { offset in
+            guard let date = calendar.date(byAdding: .day, value: offset, to: weekStart) else { return nil }
+            return formatter.string(from: date)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            navigation
+            chartSection
+        }
+        .padding()
+        .gesture(swipeGesture)
+        .navigationTitle("週ビュー")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var navigation: some View {
+        HStack {
+            Button {
+                move(weeks: -1)
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.headline)
+            }
+            .accessibilityLabel("前の週")
+
+            Spacer()
+
+            Text(rangeLabel)
+                .font(.headline)
+
+            Spacer()
+
+            Button {
+                move(weeks: 1)
+            } label: {
+                Image(systemName: "chevron.right")
+                    .font(.headline)
+            }
+            .accessibilityLabel("次の週")
+            .disabled(weekEnd > calendar.startOfDay(for: Date().addingTimeInterval(86400)))
+        }
+    }
+
+    private var chartSection: some View {
+        WeekActivityChart(weekStart: weekStart, spans: spans, weekdayLabels: weekdayLabels)
+            .frame(height: 420)
+    }
+
+    private var rangeLabel: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.dateFormat = "MMM d"
+        let last = calendar.date(byAdding: .day, value: 6, to: weekStart) ?? weekStart
+        return "\(formatter.string(from: weekStart)) – \(formatter.string(from: last))"
+    }
+
+    private var swipeGesture: some Gesture {
+        DragGesture()
+            .onEnded { value in
+                if value.translation.width > 50 {
+                    move(weeks: -1)
+                } else if value.translation.width < -50 {
+                    move(weeks: 1)
+                }
+            }
+    }
+
+    private func move(weeks: Int) {
+        if let next = calendar.date(byAdding: .day, value: weeks * 7, to: weekStart) {
+            withAnimation { weekStart = next }
+        }
+    }
+}

--- a/ios/DailyLogTests/WeekActivityLayoutTests.swift
+++ b/ios/DailyLogTests/WeekActivityLayoutTests.swift
@@ -1,0 +1,113 @@
+@testable import DailyLog
+import XCTest
+
+final class WeekActivityLayoutTests: XCTestCase {
+    private let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Tokyo") ?? .current
+        calendar.firstWeekday = 1 // 日曜始まり (Japan)
+        return calendar
+    }()
+
+    func testSingleActivityWithinOneDay() {
+        let weekStart = sunday(2026, 4, 19)
+        // Wednesday 14:00-16:30
+        let activity = makeActivity(start: date(2026, 4, 22, 14, 0), duration: 2.5 * 3600)
+
+        let spans = WeekActivityLayout.spans(for: [activity], weekStart: weekStart, calendar: calendar)
+
+        XCTAssertEqual(spans.count, 1)
+        let span = spans[0]
+        XCTAssertEqual(span.weekdayIndex, 3) // Sun=0, ..., Wed=3
+        XCTAssertEqual(span.startHours, 14, accuracy: 0.001)
+        XCTAssertEqual(span.endHours, 16.5, accuracy: 0.001)
+    }
+
+    func testActivitySpanningMidnightSplitsAcrossDays() {
+        let weekStart = sunday(2026, 4, 19)
+        // Saturday 23:00 -> Sunday 02:00 (next week begins Sunday again)
+        let activity = makeActivity(start: date(2026, 4, 25, 23, 0), duration: 3 * 3600)
+
+        let spans = WeekActivityLayout.spans(for: [activity], weekStart: weekStart, calendar: calendar)
+
+        XCTAssertEqual(spans.count, 1)
+        // The second chunk would be 2026-04-26 which is Sunday of next week — outside current week
+        let saturdaySpan = spans[0]
+        XCTAssertEqual(saturdaySpan.weekdayIndex, 6)
+        XCTAssertEqual(saturdaySpan.startHours, 23, accuracy: 0.001)
+        XCTAssertEqual(saturdaySpan.endHours, 24, accuracy: 0.001)
+    }
+
+    func testActivitySpanningMidnightWithinSameWeek() {
+        let weekStart = sunday(2026, 4, 19)
+        // Monday 22:00 -> Tuesday 01:00
+        let activity = makeActivity(start: date(2026, 4, 20, 22, 0), duration: 3 * 3600)
+
+        let spans = WeekActivityLayout.spans(for: [activity], weekStart: weekStart, calendar: calendar)
+
+        XCTAssertEqual(spans.count, 2)
+        XCTAssertEqual(spans[0].weekdayIndex, 1)
+        XCTAssertEqual(spans[0].startHours, 22, accuracy: 0.001)
+        XCTAssertEqual(spans[0].endHours, 24, accuracy: 0.001)
+        XCTAssertEqual(spans[1].weekdayIndex, 2)
+        XCTAssertEqual(spans[1].startHours, 0, accuracy: 0.001)
+        XCTAssertEqual(spans[1].endHours, 1, accuracy: 0.001)
+    }
+
+    func testActivityOutsideWeekIsExcluded() {
+        let weekStart = sunday(2026, 4, 19)
+        let before = makeActivity(start: date(2026, 4, 18, 10, 0), duration: 2 * 3600)
+        let after = makeActivity(start: date(2026, 4, 27, 10, 0), duration: 2 * 3600)
+
+        let spans = WeekActivityLayout.spans(for: [before, after], weekStart: weekStart, calendar: calendar)
+
+        XCTAssertTrue(spans.isEmpty)
+    }
+
+    func testInProgressActivityClipsToNow() {
+        let weekStart = sunday(2026, 4, 19)
+        // Starts Monday 10:00, in progress; "now" is Monday 12:30
+        let start = date(2026, 4, 20, 10, 0)
+        let now = date(2026, 4, 20, 12, 30)
+        let activity = Activity(startAt: start, endAt: nil)
+
+        let spans = WeekActivityLayout.spans(
+            for: [activity],
+            weekStart: weekStart,
+            calendar: calendar,
+            now: now
+        )
+
+        XCTAssertEqual(spans.count, 1)
+        XCTAssertEqual(spans[0].startHours, 10, accuracy: 0.001)
+        XCTAssertEqual(spans[0].endHours, 12.5, accuracy: 0.001)
+    }
+
+    func testWeekStartContainingUsesCalendarFirstWeekday() {
+        // 2026-04-22 is Wednesday. Week starts on Sunday = 2026-04-19.
+        let reference = date(2026, 4, 22, 12, 0)
+        let weekStart = WeekActivityLayout.weekStart(containing: reference, calendar: calendar)
+        XCTAssertEqual(weekStart, sunday(2026, 4, 19))
+    }
+
+    // MARK: - Helpers
+
+    private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int = 0, _ minute: Int = 0) -> Date {
+        let components = DateComponents(
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute
+        )
+        return calendar.date(from: components) ?? Date()
+    }
+
+    private func sunday(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        date(year, month, day, 0, 0)
+    }
+
+    private func makeActivity(start: Date, duration: TimeInterval) -> Activity {
+        Activity(startAt: start, endAt: start.addingTimeInterval(duration))
+    }
+}


### PR DESCRIPTION
## Summary
統計タブを新設し、縦軸 24 時間 × 横軸 7 曜日で記録を色付きブロック表示する週チャートを実装。

### 新要素
- `WeekActivityLayout.spans(for:weekStart:calendar:now:)`: `[Activity]` を `(weekdayIndex, startHours, endHours, colorHex, templateName)` に変換。日跨ぎは日単位で分割、週外は除外、進行中は `now` でクリップ
- `WeekActivityLayout.weekStart(containing:)`: `Calendar.firstWeekday` に従う週頭計算 (日本は日曜、独は月曜)
- `WeekActivityChart`: `RectangleMark` で `xStart/xEnd` (曜日 ±0.4)、`yStart/yEnd` (0-24)。曜日ラベルは `@ViewBuilder` でサブ抽出してコンパイラ時間超過を回避
- `WeekChartView`: 前/次週ボタン + 水平スワイプ (50pt閾値)。翌日以降への移動は disable
- `StatsView` タブを `MainTabView` に追加

## Tests (+6 / 44 total)
- 単一日内 Activity: 正しい weekdayIndex と端数時間
- 翌週日曜に跨ぐ土曜 23:00-02:00: 週内分のみ
- 同週内で日跨ぎ Monday 22-Tuesday 01: 2 span
- 週外 Activity: 除外
- 進行中: `now` でクリップ
- `weekStart(containing:)` が `firstWeekday` を尊重

## Verification (local)
- [x] `swiftformat --lint` / `swiftlint --strict` clean
- [x] `make -C ios build` SUCCEEDED
- [x] `make -C ios test` 44/44 passed

## Notes
- #16 日別円グラフ / #17 週月統計サマリーは `StatsView` の兄弟として追加予定

Closes #15
Refs #16 #17