### PR TITLE
TASK-16: 日別円グラフ (Swift Charts SectorMark)

### DIFF
--- a/ios/DailyLog/Utilities/DayActivitySummary.swift
+++ b/ios/DailyLog/Utilities/DayActivitySummary.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// 1 日分の Activity をテンプレート別に集計して円グラフ用のスライスに変換する。
+enum DayActivitySummary {
+    struct Slice: Identifiable, Equatable {
+        let id = UUID()
+        let templateID: UUID? // nil は未分類
+        let templateName: String
+        let colorHex: String
+        let totalSeconds: TimeInterval
+    }
+
+    /// 指定日の Activity をテンプレートごとに合算。合計秒数降順でソート。
+    /// 日付境界をまたぐ Activity はその日に属する時間分のみを計上する。
+    /// 進行中 Activity は `now` でクリップ。
+    static func slices(
+        for activities: [Activity],
+        on day: Date,
+        calendar: Calendar = .currentGregorian,
+        now: Date = Date()
+    ) -> [Slice] {
+        let dayStart = calendar.startOfDay(for: day)
+        guard let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) else { return [] }
+
+        struct Bucket {
+            var name: String
+            var colorHex: String
+            var seconds: TimeInterval
+        }
+
+        var buckets: [UUID?: Bucket] = [:]
+
+        for activity in activities {
+            let effectiveEnd = activity.endAt ?? now
+            let clippedStart = max(activity.startAt, dayStart)
+            let clippedEnd = min(effectiveEnd, dayEnd)
+            guard clippedEnd > clippedStart else { continue }
+            let seconds = clippedEnd.timeIntervalSince(clippedStart)
+
+            let key: UUID? = activity.template?.id
+            let name = activity.template?.name ?? "（未分類）"
+            let color = activity.template?.colorHex ?? "#7F8C8D"
+            if var existing = buckets[key] {
+                existing.seconds += seconds
+                buckets[key] = existing
+            } else {
+                buckets[key] = Bucket(name: name, colorHex: color, seconds: seconds)
+            }
+        }
+
+        return buckets
+            .map { key, bucket in
+                Slice(
+                    templateID: key,
+                    templateName: bucket.name,
+                    colorHex: bucket.colorHex,
+                    totalSeconds: bucket.seconds
+                )
+            }
+            .sorted { $0.totalSeconds > $1.totalSeconds }
+    }
+}

--- a/ios/DailyLog/Views/Calendar/DayDetailView.swift
+++ b/ios/DailyLog/Views/Calendar/DayDetailView.swift
@@ -2,7 +2,7 @@ import SwiftData
 import SwiftUI
 
 /// カレンダーから日付をタップしたときに開く 1 日の詳細画面。
-/// 円グラフは #16 で本実装する (ここでは一覧表示のみ)。
+/// 円グラフ + 記録リストで構成。
 struct DayDetailView: View {
     let date: Date
 
@@ -13,11 +13,20 @@ struct DayDetailView: View {
         ActivityDateExtractor.activities(on: date, from: allActivities)
     }
 
+    private var slices: [DayActivitySummary.Slice] {
+        DayActivitySummary.slices(for: allActivities, on: date)
+    }
+
     var body: some View {
         List {
             Section("サマリー") {
                 LabeledContent("記録数", value: "\(activities.count)")
                 LabeledContent("合計時間", value: totalDurationText)
+            }
+
+            Section("内訳") {
+                DayPieChart(slices: slices)
+                    .padding(.vertical, 8)
             }
 
             Section("記録") {
@@ -29,12 +38,6 @@ struct DayDetailView: View {
                         DayActivityRow(activity: activity)
                     }
                 }
-            }
-
-            Section {
-                Text("円グラフは今後 Issue #16 で実装予定")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
             }
         }
         .navigationTitle(titleText)

--- a/ios/DailyLog/Views/Stats/DayPieChart.swift
+++ b/ios/DailyLog/Views/Stats/DayPieChart.swift
@@ -1,0 +1,82 @@
+import Charts
+import SwiftUI
+
+struct DayPieChart: View {
+    let slices: [DayActivitySummary.Slice]
+
+    @State private var selectedID: UUID?
+
+    var body: some View {
+        VStack(spacing: 16) {
+            if slices.isEmpty {
+                emptyState
+            } else {
+                chart
+                legend
+            }
+        }
+    }
+
+    private var chart: some View {
+        Chart {
+            ForEach(slices) { slice in
+                SectorMark(
+                    angle: .value("時間", slice.totalSeconds),
+                    innerRadius: .ratio(0.55),
+                    angularInset: 1
+                )
+                .foregroundStyle(Color(hex: slice.colorHex) ?? .accentColor)
+                .opacity(selectedID == nil || selectedID == slice.id ? 1 : 0.35)
+                .cornerRadius(4)
+            }
+        }
+        .chartLegend(.hidden)
+        .frame(height: 220)
+    }
+
+    private var legend: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(slices) { slice in
+                Button {
+                    selectedID = selectedID == slice.id ? nil : slice.id
+                } label: {
+                    legendRow(for: slice)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func legendRow(for slice: DayActivitySummary.Slice) -> some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(Color(hex: slice.colorHex) ?? .accentColor)
+                .frame(width: 12, height: 12)
+            Text(slice.templateName)
+                .font(.subheadline)
+            Spacer()
+            Text(DurationFormatter.elapsed(seconds: Int(slice.totalSeconds)))
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(selectedID == slice.id ? Color.accentColor.opacity(0.15) : Color.clear)
+        )
+        .contentShape(Rectangle())
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "chart.pie")
+                .font(.title)
+                .foregroundStyle(.secondary)
+            Text("この日の記録はありません")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 40)
+    }
+}

--- a/ios/DailyLogTests/DayActivitySummaryTests.swift
+++ b/ios/DailyLogTests/DayActivitySummaryTests.swift
@@ -1,0 +1,102 @@
+@testable import DailyLog
+import XCTest
+
+final class DayActivitySummaryTests: XCTestCase {
+    private let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Tokyo") ?? .current
+        return calendar
+    }()
+
+    func testAggregatesByTemplate() {
+        let work = ActivityTemplate(name: "仕事", colorHex: "#111111")
+        let meal = ActivityTemplate(name: "食事", colorHex: "#222222")
+
+        let day = date(2026, 4, 25)
+        let activities = [
+            makeActivity(template: work, start: date(2026, 4, 25, 9, 0), duration: 3600),
+            makeActivity(template: work, start: date(2026, 4, 25, 13, 0), duration: 1800),
+            makeActivity(template: meal, start: date(2026, 4, 25, 12, 0), duration: 1800),
+        ]
+
+        let slices = DayActivitySummary.slices(for: activities, on: day, calendar: calendar)
+
+        XCTAssertEqual(slices.count, 2)
+        // Sorted by totalSeconds descending: 仕事 (5400) > 食事 (1800)
+        XCTAssertEqual(slices[0].templateName, "仕事")
+        XCTAssertEqual(slices[0].totalSeconds, 5400, accuracy: 0.001)
+        XCTAssertEqual(slices[1].templateName, "食事")
+        XCTAssertEqual(slices[1].totalSeconds, 1800, accuracy: 0.001)
+    }
+
+    func testClipsAtDayBoundaries() {
+        let work = ActivityTemplate(name: "仕事", colorHex: "#111111")
+        let day = date(2026, 4, 25)
+
+        // Starts 2026-04-24 23:00, ends 2026-04-25 02:00. Only 2h falls on day 25.
+        let activity = makeActivity(
+            template: work,
+            start: date(2026, 4, 24, 23, 0),
+            duration: 3 * 3600
+        )
+
+        let slices = DayActivitySummary.slices(for: [activity], on: day, calendar: calendar)
+
+        XCTAssertEqual(slices.count, 1)
+        XCTAssertEqual(slices[0].totalSeconds, 2 * 3600, accuracy: 0.001)
+    }
+
+    func testInProgressClipsToNow() {
+        let work = ActivityTemplate(name: "仕事", colorHex: "#111111")
+        let day = date(2026, 4, 25)
+        let activity = Activity(template: work, startAt: date(2026, 4, 25, 8, 0), endAt: nil)
+
+        let slices = DayActivitySummary.slices(
+            for: [activity],
+            on: day,
+            calendar: calendar,
+            now: date(2026, 4, 25, 10, 30)
+        )
+
+        XCTAssertEqual(slices[0].totalSeconds, 2.5 * 3600, accuracy: 0.001)
+    }
+
+    func testActivityWithoutTemplateIsBucketedAsUncategorized() {
+        let day = date(2026, 4, 25)
+        let activity = makeActivity(template: nil, start: date(2026, 4, 25, 10, 0), duration: 1800)
+
+        let slices = DayActivitySummary.slices(for: [activity], on: day, calendar: calendar)
+
+        XCTAssertEqual(slices.count, 1)
+        XCTAssertEqual(slices[0].templateID, nil)
+        XCTAssertEqual(slices[0].templateName, "（未分類）")
+    }
+
+    func testActivitiesOutsideTheDayAreExcluded() {
+        let work = ActivityTemplate(name: "仕事", colorHex: "#111111")
+        let day = date(2026, 4, 25)
+        let before = makeActivity(template: work, start: date(2026, 4, 23, 10, 0), duration: 3600)
+        let after = makeActivity(template: work, start: date(2026, 4, 27, 10, 0), duration: 3600)
+
+        let slices = DayActivitySummary.slices(for: [before, after], on: day, calendar: calendar)
+
+        XCTAssertTrue(slices.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int = 0, _ minute: Int = 0) -> Date {
+        let components = DateComponents(
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute
+        )
+        return calendar.date(from: components) ?? Date()
+    }
+
+    private func makeActivity(template: ActivityTemplate?, start: Date, duration: TimeInterval) -> Activity {
+        Activity(template: template, startAt: start, endAt: start.addingTimeInterval(duration))
+    }
+}


### PR DESCRIPTION
## Summary
`DayDetailView` の内訳セクションに SectorMark の円グラフを追加。凡例タップで該当スライスをハイライト。

### 追加
- `DayActivitySummary.slices(for:on:calendar:now:)`: テンプレ別に秒数集計、降順。日境界を跨ぐ Activity はその日の区間のみ。進行中は `now` でクリップ。テンプレ無しは "（未分類）"
- `DayPieChart`: `SectorMark(innerRadius: .ratio(0.55), angularInset: 1)`。凡例タップで該当スライスを残し他を opacity 0.35 にフェード
- `DayDetailView`: プレースホルダ削除、「内訳」セクションに `DayPieChart` を配置

## Tests (+5 / 49 total)
- テンプレ別集計 + 秒数降順
- 日跨ぎ Activity の境界クリップ
- 進行中 Activity の `now` クリップ
- テンプレ無し → 未分類バケツ
- 日外 Activity は除外

## Verification (local)
- [x] `swiftformat --lint` / `swiftlint --strict` clean
- [x] `make -C ios build` SUCCEEDED
- [x] `make -C ios test` 49/49 passed

Closes #16