### PR TITLE
TASK-17: 週/月統計画面 (合計時間バー + 食事サマリー)

### DIFF
--- a/ios/DailyLog/Utilities/PeriodActivitySummary.swift
+++ b/ios/DailyLog/Utilities/PeriodActivitySummary.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+/// 週/月単位の Activity 集計。
+/// - カテゴリ (テンプレート) 別合計: 親テンプレは自分 + 子の合算値を持つ
+/// - 食事サマリー: 食事タイプ Activity の件数と写真枚数
+enum PeriodActivitySummary {
+    enum Period: String, Hashable, CaseIterable, Identifiable {
+        case week
+        case month
+
+        var id: String { rawValue }
+
+        var displayName: String {
+            switch self {
+            case .week: "週"
+            case .month: "月"
+            }
+        }
+
+        func range(
+            containing date: Date,
+            calendar: Calendar = .currentGregorian
+        ) -> (start: Date, end: Date) {
+            switch self {
+            case .week:
+                let start = WeekActivityLayout.weekStart(containing: date, calendar: calendar)
+                let end = calendar.date(byAdding: .day, value: 7, to: start) ?? start
+                return (start, end)
+            case .month:
+                let components = calendar.dateComponents([.year, .month], from: date)
+                let start = calendar.date(from: components) ?? date
+                let end = calendar.date(byAdding: .month, value: 1, to: start) ?? start
+                return (start, end)
+            }
+        }
+
+        func shift(_ delta: Int, from date: Date, calendar: Calendar = .currentGregorian) -> Date {
+            switch self {
+            case .week:
+                calendar.date(byAdding: .day, value: 7 * delta, to: date) ?? date
+            case .month:
+                calendar.date(byAdding: .month, value: delta, to: date) ?? date
+            }
+        }
+    }
+
+    struct CategoryStats: Identifiable, Equatable {
+        let id: UUID
+        let templateName: String
+        let colorHex: String
+        let totalSeconds: TimeInterval
+        let children: [CategoryStats]
+    }
+
+    struct MealStats: Equatable {
+        let activityCount: Int
+        let photoCount: Int
+    }
+
+    struct Summary: Equatable {
+        let categories: [CategoryStats]
+        let meal: MealStats
+        let start: Date
+        let end: Date
+    }
+
+    private struct Bucket {
+        let template: ActivityTemplate
+        var seconds: TimeInterval
+    }
+
+    static func summarize(
+        activities: [Activity],
+        period: Period,
+        referenceDate: Date = Date(),
+        calendar: Calendar = .currentGregorian,
+        now: Date = Date()
+    ) -> Summary {
+        let (start, end) = period.range(containing: referenceDate, calendar: calendar)
+        let (buckets, meal) = aggregateBuckets(activities: activities, start: start, end: end, now: now)
+        let completeBuckets = fillMissingParents(in: buckets)
+        let categories = buildCategoryTree(from: completeBuckets)
+        return Summary(categories: categories, meal: meal, start: start, end: end)
+    }
+
+    private static func aggregateBuckets(
+        activities: [Activity],
+        start: Date,
+        end: Date,
+        now: Date
+    ) -> (buckets: [UUID: Bucket], meal: MealStats) {
+        var buckets: [UUID: Bucket] = [:]
+        var mealCount = 0
+        var photoCount = 0
+
+        for activity in activities {
+            let effectiveEnd = activity.endAt ?? now
+            guard activity.startAt < end, effectiveEnd > start else { continue }
+            let clippedStart = max(activity.startAt, start)
+            let clippedEnd = min(effectiveEnd, end)
+            let seconds = max(0, clippedEnd.timeIntervalSince(clippedStart))
+
+            guard let template = activity.template else { continue }
+            if var existing = buckets[template.id] {
+                existing.seconds += seconds
+                buckets[template.id] = existing
+            } else {
+                buckets[template.id] = Bucket(template: template, seconds: seconds)
+            }
+            if template.isMealType {
+                mealCount += 1
+                photoCount += activity.meal?.photoFilenames.count ?? 0
+            }
+        }
+
+        return (buckets, MealStats(activityCount: mealCount, photoCount: photoCount))
+    }
+
+    private static func fillMissingParents(in buckets: [UUID: Bucket]) -> [UUID: Bucket] {
+        var result = buckets
+        for (_, bucket) in buckets {
+            if let parent = bucket.template.parent, result[parent.id] == nil {
+                result[parent.id] = Bucket(template: parent, seconds: 0)
+            }
+        }
+        return result
+    }
+
+    private static func buildCategoryTree(from buckets: [UUID: Bucket]) -> [CategoryStats] {
+        var childrenByParent: [UUID: [UUID]] = [:]
+        var rootIDs: [UUID] = []
+        for (id, bucket) in buckets {
+            if let parent = bucket.template.parent {
+                childrenByParent[parent.id, default: []].append(id)
+            } else {
+                rootIDs.append(id)
+            }
+        }
+        return rootIDs
+            .map { buildNode(id: $0, buckets: buckets, childrenByParent: childrenByParent) }
+            .sorted { $0.totalSeconds > $1.totalSeconds }
+    }
+
+    private static func buildNode(
+        id: UUID,
+        buckets: [UUID: Bucket],
+        childrenByParent: [UUID: [UUID]]
+    ) -> CategoryStats {
+        guard let bucket = buckets[id] else {
+            return CategoryStats(
+                id: id,
+                templateName: "—",
+                colorHex: "#7F8C8D",
+                totalSeconds: 0,
+                children: []
+            )
+        }
+        let childIDs = childrenByParent[id] ?? []
+        let children = childIDs
+            .map { buildNode(id: $0, buckets: buckets, childrenByParent: childrenByParent) }
+            .sorted { $0.totalSeconds > $1.totalSeconds }
+        let childSum = children.reduce(0) { $0 + $1.totalSeconds }
+        return CategoryStats(
+            id: id,
+            templateName: bucket.template.name,
+            colorHex: bucket.template.colorHex,
+            totalSeconds: bucket.seconds + childSum,
+            children: children
+        )
+    }
+}

--- a/ios/DailyLog/Utilities/PeriodActivitySummary.swift
+++ b/ios/DailyLog/Utilities/PeriodActivitySummary.swift
@@ -8,7 +8,9 @@ enum PeriodActivitySummary {
         case week
         case month
 
-        var id: String { rawValue }
+        var id: String {
+            rawValue
+        }
 
         var displayName: String {
             switch self {

--- a/ios/DailyLog/Views/Stats/CategoryBarChart.swift
+++ b/ios/DailyLog/Views/Stats/CategoryBarChart.swift
@@ -1,0 +1,36 @@
+import Charts
+import SwiftUI
+
+struct CategoryBarChart: View {
+    let categories: [PeriodActivitySummary.CategoryStats]
+
+    var body: some View {
+        Chart {
+            ForEach(categories) { category in
+                BarMark(
+                    x: .value("時間", category.totalSeconds / 3600),
+                    y: .value("カテゴリ", category.templateName)
+                )
+                .foregroundStyle(Color(hex: category.colorHex) ?? .accentColor)
+                .annotation(position: .trailing, alignment: .leading) {
+                    Text(DurationFormatter.elapsed(seconds: Int(category.totalSeconds)))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .chartXAxis {
+            AxisMarks(values: .automatic) { value in
+                AxisGridLine()
+                AxisValueLabel {
+                    if let hours = value.as(Double.self) {
+                        Text("\(Int(hours))h")
+                    }
+                }
+            }
+        }
+        .chartYAxis {
+            AxisMarks(position: .leading)
+        }
+    }
+}

--- a/ios/DailyLog/Views/Stats/PeriodStatsView.swift
+++ b/ios/DailyLog/Views/Stats/PeriodStatsView.swift
@@ -1,0 +1,172 @@
+import SwiftData
+import SwiftUI
+
+struct PeriodStatsView: View {
+    @Query(sort: \Activity.startAt)
+    private var allActivities: [Activity]
+
+    @State private var period: PeriodActivitySummary.Period = .week
+    @State private var referenceDate: Date = .init()
+    @State private var expandedIDs: Set<UUID> = []
+
+    private let calendar: Calendar = .currentGregorian
+
+    private var summary: PeriodActivitySummary.Summary {
+        PeriodActivitySummary.summarize(
+            activities: allActivities,
+            period: period,
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+    }
+
+    var body: some View {
+        List {
+            periodSection
+            categoriesSection
+            mealSection
+        }
+        .navigationTitle("統計サマリー")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var periodSection: some View {
+        Section {
+            Picker("期間", selection: $period) {
+                ForEach(PeriodActivitySummary.Period.allCases) { option in
+                    Text(option.displayName).tag(option)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            periodNavigation
+        }
+    }
+
+    private var periodNavigation: some View {
+        HStack {
+            Button {
+                shiftPeriod(by: -1)
+            } label: {
+                Image(systemName: "chevron.left")
+            }
+            .accessibilityLabel("前の期間")
+
+            Spacer()
+
+            Text(rangeLabel)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            Button {
+                shiftPeriod(by: 1)
+            } label: {
+                Image(systemName: "chevron.right")
+            }
+            .accessibilityLabel("次の期間")
+            .disabled(summary.end > calendar.startOfDay(for: Date().addingTimeInterval(86400)))
+        }
+    }
+
+    private var categoriesSection: some View {
+        Section("カテゴリ別") {
+            if summary.categories.isEmpty {
+                Text("この期間の記録はありません")
+                    .foregroundStyle(.secondary)
+            } else {
+                CategoryBarChart(categories: summary.categories)
+                    .frame(minHeight: CGFloat(summary.categories.count * 36 + 40))
+
+                ForEach(summary.categories) { category in
+                    CategoryRow(
+                        category: category,
+                        isExpanded: expandedIDs.contains(category.id),
+                        onToggle: { toggle(category.id) }
+                    )
+                }
+            }
+        }
+    }
+
+    private var mealSection: some View {
+        Section("食事") {
+            LabeledContent("記録", value: "\(summary.meal.activityCount) 回")
+            LabeledContent("写真", value: "\(summary.meal.photoCount) 枚")
+        }
+    }
+
+    private var rangeLabel: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.dateFormat = period == .week ? "MMM d" : "yyyy MMM"
+        let endInclusive = calendar.date(byAdding: .day, value: -1, to: summary.end) ?? summary.end
+        if period == .month {
+            return formatter.string(from: summary.start)
+        }
+        return "\(formatter.string(from: summary.start)) – \(formatter.string(from: endInclusive))"
+    }
+
+    private func shiftPeriod(by delta: Int) {
+        withAnimation {
+            referenceDate = period.shift(delta, from: referenceDate, calendar: calendar)
+        }
+    }
+
+    private func toggle(_ id: UUID) {
+        if expandedIDs.contains(id) {
+            expandedIDs.remove(id)
+        } else {
+            expandedIDs.insert(id)
+        }
+    }
+}
+
+private struct CategoryRow: View {
+    let category: PeriodActivitySummary.CategoryStats
+    let isExpanded: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Button(action: onToggle) {
+                HStack {
+                    Circle()
+                        .fill(Color(hex: category.colorHex) ?? .accentColor)
+                        .frame(width: 12, height: 12)
+                    Text(category.templateName)
+                        .font(.body)
+                    Spacer()
+                    Text(DurationFormatter.elapsed(seconds: Int(category.totalSeconds)))
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                    if !category.children.isEmpty {
+                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                ForEach(category.children) { child in
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(Color(hex: child.colorHex) ?? .accentColor)
+                            .frame(width: 8, height: 8)
+                        Text(child.templateName)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        Text(DurationFormatter.elapsed(seconds: Int(child.totalSeconds)))
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.leading, 20)
+                }
+            }
+        }
+    }
+}

--- a/ios/DailyLog/Views/Stats/StatsView.swift
+++ b/ios/DailyLog/Views/Stats/StatsView.swift
@@ -8,7 +8,9 @@ struct StatsView: View {
                     NavigationLink("週 24 時間チャート") {
                         WeekChartView()
                     }
-                    // #16 日別円グラフ / #17 週月統計 は追って追加
+                    NavigationLink("週/月サマリー") {
+                        PeriodStatsView()
+                    }
                 }
             }
             .navigationTitle("統計")

--- a/ios/DailyLogTests/PeriodActivitySummaryTests.swift
+++ b/ios/DailyLogTests/PeriodActivitySummaryTests.swift
@@ -1,0 +1,153 @@
+@testable import DailyLog
+import XCTest
+
+final class PeriodActivitySummaryTests: XCTestCase {
+    private let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Tokyo") ?? .current
+        calendar.firstWeekday = 1 // Sunday
+        return calendar
+    }()
+
+    func testWeekRangeCoversSevenDaysStartingFromFirstWeekday() {
+        let reference = date(2026, 4, 22, 12, 0) // Wednesday
+        let range = PeriodActivitySummary.Period.week.range(containing: reference, calendar: calendar)
+
+        XCTAssertEqual(range.start, date(2026, 4, 19))
+        XCTAssertEqual(range.end, date(2026, 4, 26))
+    }
+
+    func testMonthRangeCoversCalendarMonth() {
+        let reference = date(2026, 4, 22, 12, 0)
+        let range = PeriodActivitySummary.Period.month.range(containing: reference, calendar: calendar)
+
+        XCTAssertEqual(range.start, date(2026, 4, 1))
+        XCTAssertEqual(range.end, date(2026, 5, 1))
+    }
+
+    func testWeekSummaryAggregatesByTemplate() {
+        let work = ActivityTemplate(name: "仕事", colorHex: "#111111")
+        let meal = ActivityTemplate(name: "食事", colorHex: "#222222", isMealType: true)
+
+        let activities = [
+            Activity(template: work, startAt: date(2026, 4, 20, 9, 0), endAt: date(2026, 4, 20, 12, 0)),
+            Activity(template: work, startAt: date(2026, 4, 21, 13, 0), endAt: date(2026, 4, 21, 15, 0)),
+            Activity(template: meal, startAt: date(2026, 4, 20, 12, 0), endAt: date(2026, 4, 20, 13, 0)),
+        ]
+
+        let summary = PeriodActivitySummary.summarize(
+            activities: activities,
+            period: .week,
+            referenceDate: date(2026, 4, 22, 12, 0),
+            calendar: calendar
+        )
+
+        XCTAssertEqual(summary.categories.count, 2)
+        XCTAssertEqual(summary.categories[0].templateName, "仕事")
+        XCTAssertEqual(summary.categories[0].totalSeconds, 5 * 3600, accuracy: 0.001)
+        XCTAssertEqual(summary.categories[1].templateName, "食事")
+        XCTAssertEqual(summary.categories[1].totalSeconds, 3600, accuracy: 0.001)
+    }
+
+    func testChildTemplateRollsUpUnderParent() {
+        let work = ActivityTemplate(name: "仕事", colorHex: "#111111")
+        let meeting = ActivityTemplate(name: "会議", colorHex: "#333333", parent: work)
+
+        let activities = [
+            Activity(template: work, startAt: date(2026, 4, 20, 9, 0), endAt: date(2026, 4, 20, 11, 0)),
+            Activity(template: meeting, startAt: date(2026, 4, 20, 14, 0), endAt: date(2026, 4, 20, 15, 0)),
+        ]
+
+        let summary = PeriodActivitySummary.summarize(
+            activities: activities,
+            period: .week,
+            referenceDate: date(2026, 4, 22, 12, 0),
+            calendar: calendar
+        )
+
+        XCTAssertEqual(summary.categories.count, 1)
+        let workCategory = summary.categories[0]
+        XCTAssertEqual(workCategory.templateName, "仕事")
+        XCTAssertEqual(workCategory.totalSeconds, 3 * 3600, accuracy: 0.001) // 2h parent + 1h child
+        XCTAssertEqual(workCategory.children.count, 1)
+        XCTAssertEqual(workCategory.children[0].templateName, "会議")
+        XCTAssertEqual(workCategory.children[0].totalSeconds, 3600, accuracy: 0.001)
+    }
+
+    func testOnlyChildRecordedStillShowsParentRoot() {
+        let work = ActivityTemplate(name: "仕事", colorHex: "#111111")
+        let meeting = ActivityTemplate(name: "会議", colorHex: "#333333", parent: work)
+
+        let activities = [
+            Activity(template: meeting, startAt: date(2026, 4, 20, 14, 0), endAt: date(2026, 4, 20, 16, 0)),
+        ]
+
+        let summary = PeriodActivitySummary.summarize(
+            activities: activities,
+            period: .week,
+            referenceDate: date(2026, 4, 22, 12, 0),
+            calendar: calendar
+        )
+
+        XCTAssertEqual(summary.categories.count, 1)
+        XCTAssertEqual(summary.categories[0].templateName, "仕事")
+        XCTAssertEqual(summary.categories[0].totalSeconds, 2 * 3600, accuracy: 0.001)
+        XCTAssertEqual(summary.categories[0].children.map(\.templateName), ["会議"])
+    }
+
+    func testMealStatsCountActivitiesAndPhotos() {
+        let meal = ActivityTemplate(name: "食事", colorHex: "#F5A623", isMealType: true)
+
+        let lunch = Activity(
+            template: meal,
+            startAt: date(2026, 4, 20, 12, 0),
+            endAt: date(2026, 4, 20, 13, 0)
+        )
+        lunch.meal = Meal(activity: lunch, photoFilenames: ["a.jpg", "b.jpg"])
+
+        let dinner = Activity(
+            template: meal,
+            startAt: date(2026, 4, 21, 19, 0),
+            endAt: date(2026, 4, 21, 20, 0)
+        )
+        dinner.meal = Meal(activity: dinner, photoFilenames: ["c.jpg"])
+
+        let summary = PeriodActivitySummary.summarize(
+            activities: [lunch, dinner],
+            period: .week,
+            referenceDate: date(2026, 4, 22, 12, 0),
+            calendar: calendar
+        )
+
+        XCTAssertEqual(summary.meal.activityCount, 2)
+        XCTAssertEqual(summary.meal.photoCount, 3)
+    }
+
+    func testActivitiesOutsidePeriodAreExcluded() {
+        let work = ActivityTemplate(name: "仕事", colorHex: "#111111")
+        let before = Activity(template: work, startAt: date(2026, 4, 10, 9, 0), endAt: date(2026, 4, 10, 11, 0))
+        let after = Activity(template: work, startAt: date(2026, 4, 27, 9, 0), endAt: date(2026, 4, 27, 11, 0))
+
+        let summary = PeriodActivitySummary.summarize(
+            activities: [before, after],
+            period: .week,
+            referenceDate: date(2026, 4, 22, 12, 0),
+            calendar: calendar
+        )
+
+        XCTAssertTrue(summary.categories.isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private func date(_ year: Int, _ month: Int, _ day: Int, _ hour: Int = 0, _ minute: Int = 0) -> Date {
+        let components = DateComponents(
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute
+        )
+        return calendar.date(from: components) ?? Date()
+    }
+}


### PR DESCRIPTION
## Summary
期間切替 (週/月) + カテゴリ別合計時間の棒グラフ + 階層表示 + 食事サマリーを実装。

### ロジック (`PeriodActivitySummary`)
- `Period` (週/月): `range(containing:)`, `shift(_:from:)`
- `summarize(...)` を 3 ヘルパーに分割 (function_body_length 対策):
  - `aggregateBuckets`: 期間内で区間クリップしつつテンプレ別秒数を合算、食事カウント
  - `fillMissingParents`: 子のみ記録された場合でも親を 0 秒で挿入
  - `buildCategoryTree`: 親 = 自分 + 子の合計 (棒グラフでルート表示時に正しく大きさ反映)

### UI
- `PeriodStatsView`: Picker (週/月) + prev/next ボタン + `CategoryBarChart` + 展開可能 `CategoryRow` + 食事 LabeledContent
- `CategoryBarChart`: `BarMark` (横) + `.annotation` で時間ラベル
- `StatsView` に "週/月サマリー" NavigationLink 追加

## Tests (+7 / 56 total)
- 週 range が `firstWeekday` (日曜始まり) を尊重
- 月 range が暦月を正確にカバー
- テンプレ別集計 + 降順ソート
- 子が親の下にロールアップ
- 親が記録無し & 子のみ → 親がルートに現れる
- 食事件数 / 写真枚数の合算
- 期間外 Activity は除外

## Verification (local)
- [x] `swiftformat --lint` / `swiftlint --strict` clean
- [x] `make -C ios build` SUCCEEDED
- [x] `make -C ios test` 56/56 passed

Closes #17