### PR TITLE
TASK-19: Live Activity (ActivityKit)

### DIFF
--- a/ios/DailyLog/Services/ActivityService.swift
+++ b/ios/DailyLog/Services/ActivityService.swift
@@ -30,6 +30,8 @@ struct ActivityService {
         try context.save()
         notifier.scheduleReminder(for: activity)
         publishSnapshot(for: activity)
+        Task { await LiveActivityController.shared.endAll() }
+        LiveActivityController.shared.start(template: template, startAt: now)
         return activity
     }
 
@@ -42,6 +44,7 @@ struct ActivityService {
         }
         if !closed.isEmpty {
             publishSnapshot(for: nil)
+            Task { await LiveActivityController.shared.endAll() }
         }
         return closed.first
     }

--- a/ios/DailyLog/Services/LiveActivityController.swift
+++ b/ios/DailyLog/Services/LiveActivityController.swift
@@ -1,0 +1,40 @@
+import ActivityKit
+import Foundation
+
+/// 行動開始/停止に連動して ActivityKit の Live Activity を制御する。
+///
+/// `ActivityKit.Activity` と SwiftData の `Activity` クラスが同名なので、
+/// 明示的なフルパスで参照する。
+@MainActor
+struct LiveActivityController {
+    static let shared = LiveActivityController()
+
+    func start(template: ActivityTemplate, startAt: Date) {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+
+        let attributes = DailyLogActivityAttributes(
+            templateName: template.name,
+            iconName: template.iconName,
+            colorHex: template.colorHex,
+            isMealType: template.isMealType
+        )
+        let state = DailyLogActivityAttributes.ContentState(startAt: startAt)
+        let content = ActivityContent(state: state, staleDate: nil)
+
+        do {
+            _ = try ActivityKit.Activity<DailyLogActivityAttributes>.request(
+                attributes: attributes,
+                content: content,
+                pushType: nil
+            )
+        } catch {
+            // ユーザー拒否など。失敗は silent (アプリ本体は動作継続)。
+        }
+    }
+
+    func endAll() async {
+        for activity in ActivityKit.Activity<DailyLogActivityAttributes>.activities {
+            await activity.end(nil, dismissalPolicy: .immediate)
+        }
+    }
+}

--- a/ios/DailyLogWidget/DailyLogLiveActivity.swift
+++ b/ios/DailyLogWidget/DailyLogLiveActivity.swift
@@ -1,0 +1,89 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+struct DailyLogLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: DailyLogActivityAttributes.self) { context in
+            LockScreenView(context: context)
+                .activityBackgroundTint(
+                    (Color(hex: context.attributes.colorHex) ?? .accentColor).opacity(0.2)
+                )
+                .activitySystemActionForegroundColor(.primary)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    icon(for: context.attributes)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text(context.state.startAt, style: .timer)
+                        .monospacedDigit()
+                        .font(.title3)
+                        .frame(maxWidth: 72, alignment: .trailing)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text(context.attributes.templateName)
+                        .font(.headline)
+                }
+            } compactLeading: {
+                icon(for: context.attributes)
+            } compactTrailing: {
+                Text(context.state.startAt, style: .timer)
+                    .monospacedDigit()
+                    .frame(maxWidth: 52)
+            } minimal: {
+                icon(for: context.attributes)
+            }
+            .keylineTint(Color(hex: context.attributes.colorHex) ?? .accentColor)
+        }
+    }
+
+    private func icon(for attributes: DailyLogActivityAttributes) -> some View {
+        Image(systemName: attributes.iconName)
+            .font(.callout)
+            .foregroundStyle(.white)
+            .frame(width: 24, height: 24)
+            .background(
+                Circle()
+                    .fill(Color(hex: attributes.colorHex) ?? .accentColor)
+            )
+    }
+}
+
+private struct LockScreenView: View {
+    let context: ActivityViewContext<DailyLogActivityAttributes>
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                iconBadge
+                Text(context.attributes.templateName)
+                    .font(.headline)
+                Spacer()
+                if context.attributes.isMealType {
+                    Label("食事", systemImage: "fork.knife")
+                        .labelStyle(.iconOnly)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Text(context.state.startAt, style: .timer)
+                .font(.system(.largeTitle, design: .monospaced))
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+        }
+        .padding()
+    }
+
+    private var iconBadge: some View {
+        Image(systemName: context.attributes.iconName)
+            .font(.body)
+            .foregroundStyle(.white)
+            .frame(width: 32, height: 32)
+            .background(
+                Circle()
+                    .fill(Color(hex: context.attributes.colorHex) ?? .accentColor)
+            )
+    }
+}

--- a/ios/DailyLogWidget/DailyLogWidgetBundle.swift
+++ b/ios/DailyLogWidget/DailyLogWidgetBundle.swift
@@ -5,5 +5,6 @@ import WidgetKit
 struct DailyLogWidgetBundle: WidgetBundle {
     var body: some Widget {
         DailyLogWidget()
+        DailyLogLiveActivity()
     }
 }

--- a/ios/Shared/DailyLogActivityAttributes.swift
+++ b/ios/Shared/DailyLogActivityAttributes.swift
@@ -1,0 +1,17 @@
+import ActivityKit
+import Foundation
+
+/// ロック画面 / Dynamic Island 表示に使う ActivityKit の attributes。
+///
+/// 不変属性 (テンプレ情報) は `ActivityAttributes` 側、時刻のみ動的な
+/// `ContentState` 側にまとめる。
+struct DailyLogActivityAttributes: ActivityAttributes {
+    struct ContentState: Codable, Hashable {
+        let startAt: Date
+    }
+
+    let templateName: String
+    let iconName: String
+    let colorHex: String
+    let isMealType: Bool
+}


### PR DESCRIPTION
## Summary
進行中行動をロック画面と Dynamic Island に ActivityKit で表示。開始で `Activity.request`、停止/差し替えで `endAll`。

### Shared
- `DailyLogActivityAttributes`: immutable 属性 (name/icon/color/isMealType) + `ContentState.startAt`。Text(style: .timer) で時計表示なので state 更新は不要

### 本体
- `LiveActivityController`: `start(template:startAt:)` / `endAll()`。`ActivityKit.Activity` は SwiftData `Activity` と衝突するためフルパス
- `ActivityService`: `start` → `endAll` → 新規 start、`stopCurrent` → 閉じる Activity あれば `endAll`

### ウィジェット
- `DailyLogLiveActivity`:
  - Lock Screen: アイコン + 名前 + 食事バッジ + 大きな timer
  - Dynamic Island compact: アイコン + timer
  - Dynamic Island expanded: leading アイコン, trailing timer, bottom 名前
  - Minimal: アイコン
  - keyline tint はテンプレ色
- `DailyLogWidgetBundle` に `DailyLogLiveActivity` を追加

### 権限
- `NSSupportsLiveActivities = YES` は #2 で設定済み
- Live Activity はローカル起動のみ、Push capability 不要

## Tests
ActivityKit は XCTest で到達不能 (ユーザー認可 + 実機必要)。手動検証項目:
1. 初回開始で認可プロンプト
2. ロック画面表示
3. Dynamic Island compact/expanded/minimal
4. 停止で即座に消える

## Verification (local)
- [x] `swiftformat --lint` / `swiftlint --strict` clean
- [x] `make -C ios build` SUCCEEDED
- [x] `make -C ios test` 59/59 passed

Closes #19