### PR TITLE
TASK-20: 設定画面 (iCloud 同期 / 通知 / テンプレ再追加)

### DIFF
--- a/ios/DailyLog/Models/AppModelContainer.swift
+++ b/ios/DailyLog/Models/AppModelContainer.swift
@@ -10,16 +10,39 @@ enum AppModelContainer {
     ])
 
     static func makeContainer(inMemory: Bool = false) throws -> ModelContainer {
+        let cloudKit: ModelConfiguration.CloudKitDatabase = if inMemory || !AppPreferences.iCloudSyncEnabled {
+            .none
+        } else {
+            .automatic
+        }
         let configuration = ModelConfiguration(
             schema: schema,
             isStoredInMemoryOnly: inMemory,
-            cloudKitDatabase: .none
+            cloudKitDatabase: cloudKit
         )
         let container = try ModelContainer(for: schema, configurations: configuration)
         if !inMemory {
             try seedIfNeeded(container: container)
         }
         return container
+    }
+
+    static func reseedDefaultTemplates(in context: ModelContext) throws {
+        let existingNames = try Set(context.fetch(FetchDescriptor<ActivityTemplate>()).map(\.name))
+        let existingMaxSort = try context.fetch(FetchDescriptor<ActivityTemplate>()).map(\.sortOrder).max() ?? -1
+        var nextSort = existingMaxSort + 1
+        for preset in DefaultTemplates.presets where !existingNames.contains(preset.name) {
+            context.insert(ActivityTemplate(
+                name: preset.name,
+                iconName: preset.iconName,
+                colorHex: preset.colorHex,
+                sortOrder: nextSort,
+                reminderMinutes: preset.reminderMinutes,
+                isMealType: preset.isMealType
+            ))
+            nextSort += 1
+        }
+        try context.save()
     }
 
     private static func seedIfNeeded(container: ModelContainer) throws {

--- a/ios/DailyLog/Services/ActivityService.swift
+++ b/ios/DailyLog/Services/ActivityService.swift
@@ -28,7 +28,9 @@ struct ActivityService {
         let activity = Activity(template: template, startAt: now)
         context.insert(activity)
         try context.save()
-        notifier.scheduleReminder(for: activity)
+        if AppPreferences.notificationsEnabled {
+            notifier.scheduleReminder(for: activity)
+        }
         publishSnapshot(for: activity)
         Task { await LiveActivityController.shared.endAll() }
         LiveActivityController.shared.start(template: template, startAt: now)

--- a/ios/DailyLog/Services/AppPreferences.swift
+++ b/ios/DailyLog/Services/AppPreferences.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// アプリ起動時点で必要になる軽量な設定値。
+///
+/// `AppSettings` (SwiftData) は ModelContainer が用意されて初めて読めるため、
+/// CloudKit 切替のようにコンテナ初期化時に必要な値は UserDefaults で保持する。
+enum AppPreferences {
+    enum Keys {
+        static let iCloudSyncEnabled = "pref.iCloudSyncEnabled"
+        static let notificationsEnabled = "pref.notificationsEnabled"
+    }
+
+    private static var store: UserDefaults {
+        .standard
+    }
+
+    static var iCloudSyncEnabled: Bool {
+        get { store.bool(forKey: Keys.iCloudSyncEnabled) }
+        set { store.set(newValue, forKey: Keys.iCloudSyncEnabled) }
+    }
+
+    static var notificationsEnabled: Bool {
+        get {
+            if let value = store.object(forKey: Keys.notificationsEnabled) as? Bool {
+                return value
+            }
+            return true
+        }
+        set { store.set(newValue, forKey: Keys.notificationsEnabled) }
+    }
+}

--- a/ios/DailyLog/Views/MainTabView.swift
+++ b/ios/DailyLog/Views/MainTabView.swift
@@ -17,6 +17,11 @@ struct MainTabView: View {
                 .tabItem {
                     Label("統計", systemImage: "chart.bar")
                 }
+
+            SettingsView()
+                .tabItem {
+                    Label("設定", systemImage: "gear")
+                }
         }
     }
 }

--- a/ios/DailyLog/Views/Settings/SettingsView.swift
+++ b/ios/DailyLog/Views/Settings/SettingsView.swift
@@ -1,0 +1,102 @@
+import SwiftData
+import SwiftUI
+
+struct SettingsView: View {
+    @Environment(\.modelContext) private var modelContext
+
+    @AppStorage(AppPreferences.Keys.iCloudSyncEnabled) private var iCloudSyncEnabled = false
+    @AppStorage(AppPreferences.Keys.notificationsEnabled) private var notificationsEnabled = true
+
+    @State private var reseedConfirmation = false
+    @State private var reseedMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                syncSection
+                notificationSection
+                templatesSection
+                dataSection
+                aboutSection
+            }
+            .navigationTitle("設定")
+            .alert(
+                "メッセージ",
+                isPresented: Binding(
+                    get: { reseedMessage != nil },
+                    set: { if !$0 { reseedMessage = nil } }
+                ),
+                presenting: reseedMessage
+            ) { _ in
+                Button("OK", role: .cancel) { reseedMessage = nil }
+            } message: { message in
+                Text(message)
+            }
+            .confirmationDialog(
+                "デフォルトテンプレートを再追加しますか？",
+                isPresented: $reseedConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("追加", role: .destructive) { reseedTemplates() }
+                Button("キャンセル", role: .cancel) {}
+            }
+        }
+    }
+
+    private var syncSection: some View {
+        Section("同期") {
+            Toggle("iCloud 同期", isOn: $iCloudSyncEnabled)
+            if iCloudSyncEnabled {
+                Text("有効化の反映にはアプリの再起動が必要です。")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var notificationSection: some View {
+        Section("通知") {
+            Toggle("忘れアラート", isOn: $notificationsEnabled)
+            Text("テンプレごとの分数設定は「テンプレート管理」で行えます。")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var templatesSection: some View {
+        Section("テンプレート") {
+            Button {
+                reseedConfirmation = true
+            } label: {
+                Label("デフォルトテンプレートを再追加", systemImage: "arrow.clockwise")
+            }
+        }
+    }
+
+    private var dataSection: some View {
+        Section("データ") {
+            LabeledContent("エクスポート", value: "Issue #21 で実装")
+                .foregroundStyle(.secondary)
+            LabeledContent("インポート", value: "Issue #23 で実装")
+                .foregroundStyle(.secondary)
+            LabeledContent("iCloud Drive 自動バックアップ", value: "Issue #22 で実装")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var aboutSection: some View {
+        Section("このアプリ") {
+            LabeledContent("バージョン", value: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "-")
+            LabeledContent("ビルド", value: Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "-")
+        }
+    }
+
+    private func reseedTemplates() {
+        do {
+            try AppModelContainer.reseedDefaultTemplates(in: modelContext)
+            reseedMessage = "デフォルトテンプレートを追加しました (既存の同名テンプレはそのまま)"
+        } catch {
+            reseedMessage = error.localizedDescription
+        }
+    }
+}

--- a/ios/DailyLogTests/AppPreferencesTests.swift
+++ b/ios/DailyLogTests/AppPreferencesTests.swift
@@ -1,0 +1,32 @@
+@testable import DailyLog
+import XCTest
+
+final class AppPreferencesTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: AppPreferences.Keys.iCloudSyncEnabled)
+        UserDefaults.standard.removeObject(forKey: AppPreferences.Keys.notificationsEnabled)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: AppPreferences.Keys.iCloudSyncEnabled)
+        UserDefaults.standard.removeObject(forKey: AppPreferences.Keys.notificationsEnabled)
+        super.tearDown()
+    }
+
+    func testiCloudSyncDefaultsToFalse() {
+        XCTAssertFalse(AppPreferences.iCloudSyncEnabled)
+    }
+
+    func testNotificationsDefaultsToTrue() {
+        XCTAssertTrue(AppPreferences.notificationsEnabled)
+    }
+
+    func testTogglesPersistAcrossAccesses() {
+        AppPreferences.iCloudSyncEnabled = true
+        AppPreferences.notificationsEnabled = false
+
+        XCTAssertTrue(AppPreferences.iCloudSyncEnabled)
+        XCTAssertFalse(AppPreferences.notificationsEnabled)
+    }
+}


### PR DESCRIPTION
## Summary
設定タブを追加。iCloud 同期トグル、通知マスタートグル、デフォルトテンプレ再追加、データ管理プレースホルダ、アプリバージョン表示。

### 新要素
- `AppPreferences` (UserDefaults バック): `iCloudSyncEnabled` (default false) / `notificationsEnabled` (default true)
  - `AppSettings` (SwiftData) ではなく UserDefaults にするのは、ModelContainer 作成時 (iCloud flag 参照時) には SwiftData が読めないため
- `SettingsView`: Form (同期 / 通知 / テンプレ / データ / このアプリ)
- `AppModelContainer.makeContainer` は `AppPreferences.iCloudSyncEnabled == true` で `.automatic` に切替
- `AppModelContainer.reseedDefaultTemplates(in:)`: 既存同名を除いて 8 種を追加、sortOrder は末尾に採番
- `ActivityService`: `scheduleReminder` 前に `notificationsEnabled` を確認 (cancel は無条件)
- `MainTabView` に「設定」タブ (4 番目)

## iCloud 同期切替
`ModelContainer` はアプリ起動時に 1 回作られるため、iCloud トグル変更は **アプリ再起動必要**。設定画面で明示表示。ホットスイッチは後日必要なら別途。

## Tests (+3 / 62 total)
- iCloud デフォルト false
- 通知デフォルト true
- トグル値の UserDefaults 永続化

## Verification (local)
- [x] `swiftformat --lint` / `swiftlint --strict` clean
- [x] `make -C ios build` SUCCEEDED
- [x] `make -C ios test` 62/62 passed

Closes #20
Refs #21 #22 #23