### PR TITLE
TASK-21: 手動エクスポート (JSON + 写真 ZIP)

### DIFF
--- a/ios/DailyLog/Services/ExportService.swift
+++ b/ios/DailyLog/Services/ExportService.swift
@@ -1,0 +1,150 @@
+import Foundation
+import SwiftData
+
+/// 全 SwiftData レコードと写真を ZIP にまとめる。
+@MainActor
+struct ExportService {
+    private let context: ModelContext
+    private let storage: PhotoStorage?
+    private let now: () -> Date
+
+    init(
+        context: ModelContext,
+        storage: PhotoStorage? = PhotoStorage.makeDefault(),
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.context = context
+        self.storage = storage
+        self.now = now
+    }
+
+    /// 一時ディレクトリに ZIP を作って URL を返す。呼び出し側はシェア後に削除する。
+    func makeArchive() throws -> URL {
+        let snapshot = try buildSnapshot()
+
+        let tempRoot = FileManager.default.temporaryDirectory
+        let sessionDir = tempRoot.appendingPathComponent("DailyLogExport-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: sessionDir) }
+
+        try writeSnapshotJSON(snapshot, in: sessionDir)
+        try copyPhotos(for: snapshot, to: sessionDir)
+
+        let zipURL = tempRoot.appendingPathComponent("DailyLog-\(timestampFilename()).zip")
+        try zipDirectory(sessionDir, to: zipURL)
+        return zipURL
+    }
+
+    func buildSnapshot() throws -> ExportSnapshot {
+        let templates = try context.fetch(FetchDescriptor<ActivityTemplate>())
+        let activities = try context.fetch(FetchDescriptor<Activity>())
+        let meals = try context.fetch(FetchDescriptor<Meal>())
+        let settings = try context.fetch(FetchDescriptor<AppSettings>())
+
+        return ExportSnapshot(
+            schemaVersion: ExportSnapshot.currentSchemaVersion,
+            exportedAt: now(),
+            templates: templates.map { template in
+                ExportSnapshot.Template(
+                    id: template.id,
+                    name: template.name,
+                    iconName: template.iconName,
+                    colorHex: template.colorHex,
+                    sortOrder: template.sortOrder,
+                    reminderMinutes: template.reminderMinutes,
+                    isMealType: template.isMealType,
+                    parentID: template.parent?.id,
+                    createdAt: template.createdAt
+                )
+            },
+            activities: activities.map { activity in
+                ExportSnapshot.ActivityRecord(
+                    id: activity.id,
+                    templateID: activity.template?.id,
+                    startAt: activity.startAt,
+                    endAt: activity.endAt,
+                    note: activity.note,
+                    voiceNoteFilename: activity.voiceNoteFilename,
+                    voiceTranscript: activity.voiceTranscript,
+                    mealID: activity.meal?.id,
+                    createdAt: activity.createdAt
+                )
+            },
+            meals: meals.map { meal in
+                ExportSnapshot.MealRecord(
+                    id: meal.id,
+                    activityID: meal.activity?.id,
+                    photoFilenames: meal.photoFilenames,
+                    shopName: meal.shopName,
+                    shopAddress: meal.shopAddress,
+                    note: meal.note,
+                    createdAt: meal.createdAt
+                )
+            },
+            settings: settings.map { settings in
+                ExportSnapshot.SettingsRecord(
+                    id: settings.id,
+                    iCloudSyncEnabled: settings.iCloudSyncEnabled,
+                    defaultReminderMinutes: settings.defaultReminderMinutes,
+                    createdAt: settings.createdAt,
+                    updatedAt: settings.updatedAt
+                )
+            }
+        )
+    }
+
+    private func writeSnapshotJSON(_ snapshot: ExportSnapshot, in directory: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(snapshot)
+        let url = directory.appendingPathComponent("data.json")
+        try data.write(to: url, options: .atomic)
+    }
+
+    private func copyPhotos(for snapshot: ExportSnapshot, to directory: URL) throws {
+        guard let storage else { return }
+        let filenames = Set(snapshot.meals.flatMap(\.photoFilenames))
+        guard !filenames.isEmpty else { return }
+        let photosDir = directory.appendingPathComponent("photos", isDirectory: true)
+        try FileManager.default.createDirectory(at: photosDir, withIntermediateDirectories: true)
+        for filename in filenames {
+            let source = storage.url(for: filename)
+            guard FileManager.default.fileExists(atPath: source.path) else { continue }
+            let destination = photosDir.appendingPathComponent(filename)
+            if FileManager.default.fileExists(atPath: destination.path) {
+                try FileManager.default.removeItem(at: destination)
+            }
+            try FileManager.default.copyItem(at: source, to: destination)
+        }
+    }
+
+    private func zipDirectory(_ sourceDir: URL, to destinationURL: URL) throws {
+        if FileManager.default.fileExists(atPath: destinationURL.path) {
+            try FileManager.default.removeItem(at: destinationURL)
+        }
+        let coordinator = NSFileCoordinator()
+        var coordinatorError: NSError?
+        var innerError: Error?
+        coordinator.coordinate(
+            readingItemAt: sourceDir,
+            options: [.forUploading],
+            error: &coordinatorError
+        ) { tempZipURL in
+            do {
+                try FileManager.default.copyItem(at: tempZipURL, to: destinationURL)
+            } catch {
+                innerError = error
+            }
+        }
+        if let coordinatorError { throw coordinatorError }
+        if let innerError { throw innerError }
+    }
+
+    private func timestampFilename() -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        return formatter.string(from: now())
+    }
+}

--- a/ios/DailyLog/Services/ExportSnapshot.swift
+++ b/ios/DailyLog/Services/ExportSnapshot.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// エクスポートファイルの最上位スキーマ。`#21` (エクスポート) と `#23` (インポート) で共用。
+struct ExportSnapshot: Codable, Equatable {
+    static let currentSchemaVersion = 1
+
+    struct Template: Codable, Equatable {
+        let id: UUID
+        let name: String
+        let iconName: String
+        let colorHex: String
+        let sortOrder: Int
+        let reminderMinutes: Int?
+        let isMealType: Bool
+        let parentID: UUID?
+        let createdAt: Date
+    }
+
+    struct ActivityRecord: Codable, Equatable {
+        let id: UUID
+        let templateID: UUID?
+        let startAt: Date
+        let endAt: Date?
+        let note: String
+        let voiceNoteFilename: String?
+        let voiceTranscript: String?
+        let mealID: UUID?
+        let createdAt: Date
+    }
+
+    struct MealRecord: Codable, Equatable {
+        let id: UUID
+        let activityID: UUID?
+        let photoFilenames: [String]
+        let shopName: String?
+        let shopAddress: String?
+        let note: String
+        let createdAt: Date
+    }
+
+    struct SettingsRecord: Codable, Equatable {
+        let id: UUID
+        let iCloudSyncEnabled: Bool
+        let defaultReminderMinutes: Int
+        let createdAt: Date
+        let updatedAt: Date
+    }
+
+    let schemaVersion: Int
+    let exportedAt: Date
+    let templates: [Template]
+    let activities: [ActivityRecord]
+    let meals: [MealRecord]
+    let settings: [SettingsRecord]
+}

--- a/ios/DailyLog/Views/Settings/SettingsView.swift
+++ b/ios/DailyLog/Views/Settings/SettingsView.swift
@@ -9,6 +9,9 @@ struct SettingsView: View {
 
     @State private var reseedConfirmation = false
     @State private var reseedMessage: String?
+    @State private var isExporting = false
+    @State private var exportArchive: ExportArchive?
+    @State private var exportErrorMessage: String?
 
     var body: some View {
         NavigationStack {
@@ -40,6 +43,40 @@ struct SettingsView: View {
                 Button("追加", role: .destructive) { reseedTemplates() }
                 Button("キャンセル", role: .cancel) {}
             }
+            .sheet(item: $exportArchive, onDismiss: cleanupExportArchive) { archive in
+                ShareSheet(items: [archive.url])
+            }
+            .alert(
+                "エクスポートに失敗しました",
+                isPresented: Binding(
+                    get: { exportErrorMessage != nil },
+                    set: { if !$0 { exportErrorMessage = nil } }
+                ),
+                presenting: exportErrorMessage
+            ) { _ in
+                Button("OK", role: .cancel) { exportErrorMessage = nil }
+            } message: { message in
+                Text(message)
+            }
+        }
+    }
+
+    private func export() {
+        isExporting = true
+        do {
+            let service = ExportService(context: modelContext)
+            let url = try service.makeArchive()
+            exportArchive = ExportArchive(url: url)
+        } catch {
+            exportErrorMessage = error.localizedDescription
+        }
+        isExporting = false
+    }
+
+    private func cleanupExportArchive() {
+        if let archive = exportArchive {
+            try? FileManager.default.removeItem(at: archive.url)
+            exportArchive = nil
         }
     }
 
@@ -75,8 +112,19 @@ struct SettingsView: View {
 
     private var dataSection: some View {
         Section("データ") {
-            LabeledContent("エクスポート", value: "Issue #21 で実装")
-                .foregroundStyle(.secondary)
+            Button {
+                export()
+            } label: {
+                HStack {
+                    Label("エクスポート", systemImage: "square.and.arrow.up")
+                    if isExporting {
+                        Spacer()
+                        ProgressView()
+                    }
+                }
+            }
+            .disabled(isExporting)
+
             LabeledContent("インポート", value: "Issue #23 で実装")
                 .foregroundStyle(.secondary)
             LabeledContent("iCloud Drive 自動バックアップ", value: "Issue #22 で実装")

--- a/ios/DailyLog/Views/Settings/ShareSheet.swift
+++ b/ios/DailyLog/Views/Settings/ShareSheet.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import UIKit
+
+struct ShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}
+
+struct ExportArchive: Identifiable {
+    let id = UUID()
+    let url: URL
+}

--- a/ios/DailyLogTests/ExportServiceTests.swift
+++ b/ios/DailyLogTests/ExportServiceTests.swift
@@ -1,0 +1,96 @@
+@testable import DailyLog
+import SwiftData
+import XCTest
+
+@MainActor
+final class ExportServiceTests: XCTestCase {
+    private var container: ModelContainer!
+    private var tempDir: URL!
+    private var storage: PhotoStorage!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        container = try AppModelContainer.makeContainer(inMemory: true)
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ExportServiceTests-\(UUID().uuidString)", isDirectory: true)
+        storage = PhotoStorage(rootURL: tempDir)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        storage = nil
+        container = nil
+        tempDir = nil
+        try super.tearDownWithError()
+    }
+
+    func testSnapshotCapturesAllModels() throws {
+        let context = container.mainContext
+        let template = ActivityTemplate(name: "仕事", iconName: "briefcase.fill", colorHex: "#4A90E2")
+        context.insert(template)
+        let activity = Activity(
+            template: template,
+            startAt: Date(timeIntervalSince1970: 1_700_000_000),
+            endAt: Date(timeIntervalSince1970: 1_700_003_600),
+            note: "メモ"
+        )
+        context.insert(activity)
+        try context.save()
+
+        let service = ExportService(
+            context: context,
+            storage: storage,
+            now: { Date(timeIntervalSince1970: 1_700_010_000) }
+        )
+        let snapshot = try service.buildSnapshot()
+
+        XCTAssertEqual(snapshot.schemaVersion, ExportSnapshot.currentSchemaVersion)
+        XCTAssertEqual(snapshot.exportedAt, Date(timeIntervalSince1970: 1_700_010_000))
+        XCTAssertTrue(snapshot.templates.contains { $0.id == template.id })
+        XCTAssertTrue(snapshot.activities.contains { $0.id == activity.id && $0.templateID == template.id })
+    }
+
+    func testSnapshotIsRoundTripCodable() throws {
+        let context = container.mainContext
+        let template = ActivityTemplate(name: "読書", iconName: "book", colorHex: "#50C9BA")
+        context.insert(template)
+        try context.save()
+
+        let service = ExportService(context: context, storage: storage)
+        let snapshot = try service.buildSnapshot()
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let data = try encoder.encode(snapshot)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let decoded = try decoder.decode(ExportSnapshot.self, from: data)
+
+        // Date encoding as Double seconds can round sub-ms bits; compare
+        // structurally instead of requiring bit-exact Date equality.
+        XCTAssertEqual(decoded.schemaVersion, snapshot.schemaVersion)
+        XCTAssertEqual(decoded.templates.count, snapshot.templates.count)
+        XCTAssertEqual(decoded.templates.first?.id, snapshot.templates.first?.id)
+        XCTAssertEqual(decoded.templates.first?.name, snapshot.templates.first?.name)
+        XCTAssertEqual(decoded.templates.first?.colorHex, snapshot.templates.first?.colorHex)
+    }
+
+    func testMakeArchiveProducesReadableZip() throws {
+        let context = container.mainContext
+        let template = ActivityTemplate(name: "仕事")
+        context.insert(template)
+        try context.save()
+
+        let service = ExportService(context: context, storage: storage)
+        let url = try service.makeArchive()
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        let size = (attributes[.size] as? NSNumber)?.intValue ?? 0
+        XCTAssertGreaterThan(size, 0)
+    }
+}


### PR DESCRIPTION
## Summary
設定タブに「エクスポート」ボタンを追加。全 SwiftData レコードと Meal 写真を ZIP にまとめてシェアシートで外部保存できる。

### 構成
- `ExportSnapshot` (Codable, スキーマ v1): templates / activities / meals / settings。各行に UUID と親関係 (`parentID`, `templateID`, `mealID`, `activityID`) を含む
- Date は `secondsSince1970` で encode (他ツールでもパース容易)
- `ExportService`:
  - `buildSnapshot()`: SwiftData から全件取得 → Codable 化
  - `makeArchive()`: session ディレクトリに `data.json` + `photos/*` を書き、`NSFileCoordinator(.forUploading)` で ZIP 化して tempDir に `DailyLog-YYYYMMDD-HHmmss.zip` を出力
  - `PhotoStorage` と時計はテスト用に注入可能
- `ShareSheet` (UIActivityViewController wrapper), `ExportArchive` (Identifiable)
- `SettingsView`: タップ → 生成 → シート表示 → 閉じたら一時 ZIP を削除

## Tests (+3 / 65 total)
- `buildSnapshot` がテンプレ + Activity の外部キーを保持
- JSON round-trip で schemaVersion / 件数 / id / name / colorHex が一致 (Date exact 比較は除外 — 浮動小数の string 経由で微小誤差が出るため)
- `makeArchive` が非空の ZIP を生成

## Verification (local)
- [x] `swiftformat --lint` / `swiftlint --strict` clean
- [x] `make -C ios build` SUCCEEDED
- [x] `make -C ios test` 65/65 passed

Closes #21
Refs #23