### PR TITLE
TASK-22: iCloud Drive 手動バックアップ + 世代管理

### DIFF
--- a/ios/DailyLog/Services/BackupService.swift
+++ b/ios/DailyLog/Services/BackupService.swift
@@ -1,0 +1,72 @@
+import Foundation
+import SwiftData
+
+/// エクスポート ZIP を iCloud Drive (ubiquity container の Documents) にコピーし、
+/// 古いバックアップを世代管理する。
+@MainActor
+struct BackupService {
+    private let exporter: ExportService
+    private let targetDirectory: URL
+    private let maxRetained: Int
+
+    init(exporter: ExportService, targetDirectory: URL, maxRetained: Int = 7) {
+        self.exporter = exporter
+        self.targetDirectory = targetDirectory
+        self.maxRetained = maxRetained
+    }
+
+    /// 今すぐバックアップを作る。戻り値は保存先 URL。
+    @discardableResult
+    func performBackup() throws -> URL {
+        try FileManager.default.createDirectory(
+            at: targetDirectory,
+            withIntermediateDirectories: true
+        )
+        let archive = try exporter.makeArchive()
+        let destination = targetDirectory.appendingPathComponent(archive.lastPathComponent)
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.moveItem(at: archive, to: destination)
+        try pruneOldBackups()
+        return destination
+    }
+
+    /// 保存済みバックアップの一覧 (新しい順)。
+    func listBackups() throws -> [URL] {
+        guard FileManager.default.fileExists(atPath: targetDirectory.path) else { return [] }
+        let files = try FileManager.default.contentsOfDirectory(
+            at: targetDirectory,
+            includingPropertiesForKeys: [.creationDateKey],
+            options: [.skipsHiddenFiles]
+        )
+        return files
+            .filter { $0.pathExtension == "zip" && $0.lastPathComponent.hasPrefix("DailyLog-") }
+            .sorted { lhs, rhs in
+                let lhsDate = (try? lhs.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantPast
+                let rhsDate = (try? rhs.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? .distantPast
+                return lhsDate > rhsDate
+            }
+    }
+
+    private func pruneOldBackups() throws {
+        let backups = try listBackups()
+        guard backups.count > maxRetained else { return }
+        for url in backups.dropFirst(maxRetained) {
+            try FileManager.default.removeItem(at: url)
+        }
+    }
+
+    /// iCloud Drive 上の DailyLog/Documents/Backups フォルダ。ユーザーが iCloud に
+    /// サインインしていない場合は nil。
+    static func iCloudBackupsDirectory() -> URL? {
+        guard let container = FileManager.default.url(
+            forUbiquityContainerIdentifier: AppGroupConfig.iCloudContainerIdentifier
+        ) else {
+            return nil
+        }
+        return container
+            .appendingPathComponent("Documents", isDirectory: true)
+            .appendingPathComponent("Backups", isDirectory: true)
+    }
+}

--- a/ios/DailyLog/Views/Settings/SettingsView.swift
+++ b/ios/DailyLog/Views/Settings/SettingsView.swift
@@ -12,6 +12,8 @@ struct SettingsView: View {
     @State private var isExporting = false
     @State private var exportArchive: ExportArchive?
     @State private var exportErrorMessage: String?
+    @State private var backupMessage: String?
+    @State private var isRunningBackup = false
 
     var body: some View {
         NavigationStack {
@@ -58,6 +60,18 @@ struct SettingsView: View {
             } message: { message in
                 Text(message)
             }
+            .alert(
+                "バックアップ",
+                isPresented: Binding(
+                    get: { backupMessage != nil },
+                    set: { if !$0 { backupMessage = nil } }
+                ),
+                presenting: backupMessage
+            ) { _ in
+                Button("OK", role: .cancel) { backupMessage = nil }
+            } message: { message in
+                Text(message)
+            }
         }
     }
 
@@ -78,6 +92,25 @@ struct SettingsView: View {
             try? FileManager.default.removeItem(at: archive.url)
             exportArchive = nil
         }
+    }
+
+    private func runManualBackup() {
+        guard let target = BackupService.iCloudBackupsDirectory() else {
+            backupMessage = "iCloud Drive が利用できません。iCloud にサインインして iCloud Drive を有効にしてください。"
+            return
+        }
+        isRunningBackup = true
+        let service = BackupService(
+            exporter: ExportService(context: modelContext),
+            targetDirectory: target
+        )
+        do {
+            let url = try service.performBackup()
+            backupMessage = "バックアップしました: \(url.lastPathComponent)"
+        } catch {
+            backupMessage = error.localizedDescription
+        }
+        isRunningBackup = false
     }
 
     private var syncSection: some View {
@@ -127,8 +160,19 @@ struct SettingsView: View {
 
             LabeledContent("インポート", value: "Issue #23 で実装")
                 .foregroundStyle(.secondary)
-            LabeledContent("iCloud Drive 自動バックアップ", value: "Issue #22 で実装")
-                .foregroundStyle(.secondary)
+
+            Button {
+                runManualBackup()
+            } label: {
+                HStack {
+                    Label("今すぐ iCloud バックアップ", systemImage: "icloud.and.arrow.up")
+                    if isRunningBackup {
+                        Spacer()
+                        ProgressView()
+                    }
+                }
+            }
+            .disabled(isRunningBackup)
         }
     }
 

--- a/ios/DailyLogTests/BackupServiceTests.swift
+++ b/ios/DailyLogTests/BackupServiceTests.swift
@@ -1,0 +1,94 @@
+@testable import DailyLog
+import SwiftData
+import XCTest
+
+@MainActor
+final class BackupServiceTests: XCTestCase {
+    private var container: ModelContainer!
+    private var rootDirectory: URL!
+    private var storage: PhotoStorage!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        container = try AppModelContainer.makeContainer(inMemory: true)
+        rootDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BackupServiceTests-\(UUID().uuidString)", isDirectory: true)
+        storage = PhotoStorage(rootURL: rootDirectory.appendingPathComponent("photos"))
+    }
+
+    override func tearDownWithError() throws {
+        if let rootDirectory {
+            try? FileManager.default.removeItem(at: rootDirectory)
+        }
+        storage = nil
+        rootDirectory = nil
+        container = nil
+        try super.tearDownWithError()
+    }
+
+    func testPerformBackupProducesZipInTarget() throws {
+        let context = container.mainContext
+        context.insert(ActivityTemplate(name: "仕事"))
+        try context.save()
+
+        let target = rootDirectory.appendingPathComponent("backups")
+        let service = BackupService(
+            exporter: ExportService(context: context, storage: storage),
+            targetDirectory: target
+        )
+
+        let url = try service.performBackup()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        XCTAssertEqual(url.pathExtension, "zip")
+        let list = try service.listBackups()
+        XCTAssertEqual(list.count, 1)
+    }
+
+    func testPrunesOldBackupsBeyondLimit() throws {
+        let context = container.mainContext
+        context.insert(ActivityTemplate(name: "X"))
+        try context.save()
+
+        let target = rootDirectory.appendingPathComponent("backups")
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+
+        // Seed 5 existing backup files with distinct timestamps (oldest first).
+        var seededURLs: [URL] = []
+        for index in 0 ..< 5 {
+            let name = "DailyLog-2026010\(index)-000000.zip"
+            let url = target.appendingPathComponent(name)
+            try Data("old".utf8).write(to: url)
+            // Nudge modification date so ordering is predictable.
+            let date = Date(timeIntervalSince1970: 1_700_000_000 + Double(index) * 60)
+            try FileManager.default.setAttributes(
+                [.creationDate: date, .modificationDate: date],
+                ofItemAtPath: url.path
+            )
+            seededURLs.append(url)
+        }
+
+        let service = BackupService(
+            exporter: ExportService(context: context, storage: storage),
+            targetDirectory: target,
+            maxRetained: 3
+        )
+        _ = try service.performBackup()
+
+        let remaining = try service.listBackups()
+        XCTAssertEqual(remaining.count, 3)
+        // Oldest two should be deleted.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: seededURLs[0].path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: seededURLs[1].path))
+    }
+
+    func testListBackupsReturnsEmptyWhenDirectoryMissing() throws {
+        let context = container.mainContext
+        let target = rootDirectory.appendingPathComponent("nonexistent")
+        let service = BackupService(
+            exporter: ExportService(context: context, storage: storage),
+            targetDirectory: target
+        )
+        XCTAssertEqual(try service.listBackups(), [])
+    }
+}

--- a/ios/Shared/AppGroupConfig.swift
+++ b/ios/Shared/AppGroupConfig.swift
@@ -3,6 +3,7 @@ import Foundation
 /// 本体アプリとウィジェット拡張で共有する App Group 設定。
 enum AppGroupConfig {
     static let identifier = "group.com.coco.daily-log"
+    static let iCloudContainerIdentifier = "iCloud.com.coco.daily-log"
 
     static var sharedDefaults: UserDefaults {
         UserDefaults(suiteName: identifier) ?? .standard


### PR DESCRIPTION
## Summary
設定画面に「今すぐ iCloud バックアップ」を追加。ExportService の ZIP を iCloud Drive (ubiquity container の Documents/Backups) に保存、7 世代管理。

### スコープ
- **手動バックアップのみ**: タップで即実行
- **BGAppRefreshTask 自動化は別 PR**: `BGTaskSchedulerPermittedIdentifiers` を xcodegen の `INFOPLIST_KEY_*` で配列注入するのが煩雑なため、先に手動パスを用意して検証可能な状態にしてから追加する

### 新要素
- `AppGroupConfig.iCloudContainerIdentifier` 追加
- `BackupService`:
  - `performBackup()`: ExportService で ZIP 生成 → targetDirectory に移動 → `pruneOldBackups` で `maxRetained` (デフォルト 7) を超えた古い物を削除
  - `listBackups()`: `DailyLog-*.zip` を新しい順
  - `iCloudBackupsDirectory()`: ubiquity container の `Documents/Backups`、iCloud 無効時は nil
- `SettingsView`: 旧プレースホルダーを置換、nil の場合は "iCloud にサインインしてください" アラート、成功時はファイル名表示

## Tests (+3 / 68 total)
- `performBackup` が ZIP を target に作成、`listBackups` が返す
- 5 個の古い zip + `maxRetained=3` → 新しい 3 個のみ残る、古い 2 個は削除
- target 無い時 `listBackups` は `[]`

## Verification (local)
- [x] `swiftformat --lint` / `swiftlint --strict` clean
- [x] `make -C ios build` SUCCEEDED
- [x] `make -C ios test` 68/68 passed

## Notes
- 実機で iCloud Drive 確認必要 (#24 の Apple Dev Portal 設定 + iCloud Container 有効化後)
- 自動実行 (BGAppRefreshTask) は separate follow-up

Closes #22
Refs #23 #24