### PR TITLE
TASK-23: インポート/復元 (ZIP 展開 + マージ/置換)

### DIFF
--- a/ios/DailyLog/Services/ImportService.swift
+++ b/ios/DailyLog/Services/ImportService.swift
@@ -1,0 +1,257 @@
+import Foundation
+import SwiftData
+import ZIPFoundation
+
+/// エクスポート ZIP を読み込んで SwiftData に書き戻す。
+@MainActor
+struct ImportService {
+    enum Mode {
+        /// 既存データを保持しつつ、import 分を新規追加 or 既存 ID の上書き。
+        case merge
+        /// 既存の全 Activity / Template / Meal / AppSettings を削除してから import。
+        case replace
+    }
+
+    enum ImportError: LocalizedError {
+        case missingDataJSON
+        case unsupportedSchemaVersion(Int)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingDataJSON:
+                "バックアップに data.json が含まれていません"
+            case let .unsupportedSchemaVersion(version):
+                "未対応のスキーマバージョン: \(version)"
+            }
+        }
+    }
+
+    struct ImportResult: Equatable {
+        let templatesImported: Int
+        let activitiesImported: Int
+        let mealsImported: Int
+        let photosRestored: Int
+    }
+
+    private let context: ModelContext
+    private let storage: PhotoStorage?
+
+    init(context: ModelContext, storage: PhotoStorage? = PhotoStorage.makeDefault()) {
+        self.context = context
+        self.storage = storage
+    }
+
+    @discardableResult
+    func importArchive(at zipURL: URL, mode: Mode) throws -> ImportResult {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DailyLogImport-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        try FileManager.default.unzipItem(at: zipURL, to: tempDir)
+
+        guard let jsonURL = locateDataJSON(in: tempDir) else {
+            throw ImportError.missingDataJSON
+        }
+        let snapshot = try loadSnapshot(from: jsonURL)
+        guard snapshot.schemaVersion == ExportSnapshot.currentSchemaVersion else {
+            throw ImportError.unsupportedSchemaVersion(snapshot.schemaVersion)
+        }
+
+        if mode == .replace {
+            try deleteAllRecords()
+        }
+
+        let counts = try applySnapshot(snapshot)
+        let photoCount = try restorePhotos(from: tempDir)
+        try context.save()
+
+        return ImportResult(
+            templatesImported: counts.templates,
+            activitiesImported: counts.activities,
+            mealsImported: counts.meals,
+            photosRestored: photoCount
+        )
+    }
+
+    // MARK: - Extraction
+
+    private func locateDataJSON(in directory: URL) -> URL? {
+        let root = directory.appendingPathComponent("data.json")
+        if FileManager.default.fileExists(atPath: root.path) {
+            return root
+        }
+        let enumerator = FileManager.default.enumerator(at: directory, includingPropertiesForKeys: nil)
+        while let url = enumerator?.nextObject() as? URL {
+            if url.lastPathComponent == "data.json" {
+                return url
+            }
+        }
+        return nil
+    }
+
+    private func loadSnapshot(from url: URL) throws -> ExportSnapshot {
+        let data = try Data(contentsOf: url)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        return try decoder.decode(ExportSnapshot.self, from: data)
+    }
+
+    private func deleteAllRecords() throws {
+        try context.delete(model: Activity.self)
+        try context.delete(model: Meal.self)
+        try context.delete(model: ActivityTemplate.self)
+        try context.delete(model: AppSettings.self)
+    }
+
+    // MARK: - Apply
+
+    private struct ImportCounts {
+        let templates: Int
+        let activities: Int
+        let meals: Int
+    }
+
+    private func applySnapshot(_ snapshot: ExportSnapshot) throws -> ImportCounts {
+        let templates = try applyTemplates(snapshot.templates)
+        let activities = applyActivities(snapshot.activities, templates: templates)
+        applyMeals(snapshot.meals, activities: activities)
+        applySettings(snapshot.settings)
+        return ImportCounts(
+            templates: snapshot.templates.count,
+            activities: snapshot.activities.count,
+            meals: snapshot.meals.count
+        )
+    }
+
+    private func applyTemplates(_ records: [ExportSnapshot.Template]) throws -> [UUID: ActivityTemplate] {
+        let existing = try context.fetch(FetchDescriptor<ActivityTemplate>())
+        var templatesByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+        for record in records {
+            let template = templatesByID[record.id] ?? ActivityTemplate(name: record.name)
+            template.id = record.id
+            template.name = record.name
+            template.iconName = record.iconName
+            template.colorHex = record.colorHex
+            template.sortOrder = record.sortOrder
+            template.reminderMinutes = record.reminderMinutes
+            template.isMealType = record.isMealType
+            template.createdAt = record.createdAt
+            if templatesByID[record.id] == nil {
+                context.insert(template)
+                templatesByID[record.id] = template
+            }
+        }
+        // Second pass so parents and children both exist.
+        for record in records {
+            templatesByID[record.id]?.parent = record.parentID.flatMap { templatesByID[$0] }
+        }
+        return templatesByID
+    }
+
+    private func applyActivities(
+        _ records: [ExportSnapshot.ActivityRecord],
+        templates: [UUID: ActivityTemplate]
+    ) -> [UUID: Activity] {
+        let existing = (try? context.fetch(FetchDescriptor<Activity>())) ?? []
+        var activitiesByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+        for record in records {
+            let activity = activitiesByID[record.id] ?? Activity(startAt: record.startAt)
+            activity.id = record.id
+            activity.startAt = record.startAt
+            activity.endAt = record.endAt
+            activity.note = record.note
+            activity.voiceNoteFilename = record.voiceNoteFilename
+            activity.voiceTranscript = record.voiceTranscript
+            activity.createdAt = record.createdAt
+            activity.template = record.templateID.flatMap { templates[$0] }
+            if activitiesByID[record.id] == nil {
+                context.insert(activity)
+                activitiesByID[record.id] = activity
+            }
+        }
+        return activitiesByID
+    }
+
+    private func applyMeals(_ records: [ExportSnapshot.MealRecord], activities: [UUID: Activity]) {
+        let existing = (try? context.fetch(FetchDescriptor<Meal>())) ?? []
+        var mealsByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+        for record in records {
+            let meal = mealsByID[record.id] ?? Meal()
+            meal.id = record.id
+            meal.photoFilenames = record.photoFilenames
+            meal.shopName = record.shopName
+            meal.shopAddress = record.shopAddress
+            meal.note = record.note
+            meal.createdAt = record.createdAt
+            meal.activity = record.activityID.flatMap { activities[$0] }
+            if mealsByID[record.id] == nil {
+                context.insert(meal)
+                mealsByID[record.id] = meal
+            }
+        }
+    }
+
+    private func applySettings(_ records: [ExportSnapshot.SettingsRecord]) {
+        for record in records {
+            let settings = AppSettings(
+                id: record.id,
+                iCloudSyncEnabled: record.iCloudSyncEnabled,
+                defaultReminderMinutes: record.defaultReminderMinutes,
+                createdAt: record.createdAt,
+                updatedAt: record.updatedAt
+            )
+            context.insert(settings)
+        }
+    }
+
+    // MARK: - Photos
+
+    private func restorePhotos(from extractDir: URL) throws -> Int {
+        guard let storage else { return 0 }
+        let photosRoot: URL? = {
+            let direct = extractDir.appendingPathComponent("photos", isDirectory: true)
+            if FileManager.default.fileExists(atPath: direct.path) { return direct }
+            // Zip might have wrapped in a parent directory
+            let enumerator = FileManager.default.enumerator(
+                at: extractDir,
+                includingPropertiesForKeys: [.isDirectoryKey]
+            )
+            while let url = enumerator?.nextObject() as? URL {
+                let isDir = (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+                if isDir, url.lastPathComponent == "photos" {
+                    return url
+                }
+            }
+            return nil
+        }()
+        guard let photosRoot else { return 0 }
+
+        var restored = 0
+        let files = try FileManager.default.contentsOfDirectory(
+            at: photosRoot,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )
+        for source in files {
+            let data = try Data(contentsOf: source)
+            _ = try storage.saveJPEGPreservingFilename(data, filename: source.lastPathComponent)
+            restored += 1
+        }
+        return restored
+    }
+}
+
+extension PhotoStorage {
+    /// インポート時にファイル名を維持したまま保存したいので、通常の `save*` とは別経路。
+    @discardableResult
+    func saveJPEGPreservingFilename(_ data: Data, filename: String) throws -> String {
+        try FileManager.default.createDirectory(
+            at: rootURL,
+            withIntermediateDirectories: true
+        )
+        let url = rootURL.appendingPathComponent(filename)
+        try data.write(to: url, options: .atomic)
+        return filename
+    }
+}

--- a/ios/DailyLog/Views/Settings/SettingsView+Actions.swift
+++ b/ios/DailyLog/Views/Settings/SettingsView+Actions.swift
@@ -1,0 +1,96 @@
+import Foundation
+import SwiftUI
+
+extension SettingsView {
+    func export() {
+        isExporting = true
+        do {
+            let service = ExportService(context: modelContext)
+            let url = try service.makeArchive()
+            exportArchive = ExportArchive(url: url)
+        } catch {
+            exportErrorMessage = error.localizedDescription
+        }
+        isExporting = false
+    }
+
+    func cleanupExportArchive() {
+        if let archive = exportArchive {
+            try? FileManager.default.removeItem(at: archive.url)
+            exportArchive = nil
+        }
+    }
+
+    func handleImportSelection(_ result: Result<[URL], Error>) {
+        switch result {
+        case let .success(urls):
+            guard let url = urls.first else { return }
+            let needsScopeAccess = url.startAccessingSecurityScopedResource()
+            defer {
+                if needsScopeAccess {
+                    url.stopAccessingSecurityScopedResource()
+                }
+            }
+            let copy = FileManager.default.temporaryDirectory
+                .appendingPathComponent("import-\(UUID().uuidString).zip")
+            do {
+                if FileManager.default.fileExists(atPath: copy.path) {
+                    try FileManager.default.removeItem(at: copy)
+                }
+                try FileManager.default.copyItem(at: url, to: copy)
+                pendingImportURL = copy
+            } catch {
+                importMessage = error.localizedDescription
+            }
+        case let .failure(error):
+            importMessage = error.localizedDescription
+        }
+    }
+
+    func performImport(url: URL, mode: ImportService.Mode) {
+        defer {
+            try? FileManager.default.removeItem(at: url)
+            pendingImportURL = nil
+        }
+        let service = ImportService(context: modelContext)
+        do {
+            let result = try service.importArchive(at: url, mode: mode)
+            importMessage = [
+                "復元しました:",
+                "テンプレ \(result.templatesImported) / 行動 \(result.activitiesImported)",
+                "食事 \(result.mealsImported) / 写真 \(result.photosRestored)",
+                "反映にはアプリの再起動を推奨します。",
+            ].joined(separator: "\n")
+        } catch {
+            importMessage = error.localizedDescription
+        }
+    }
+
+    func runManualBackup() {
+        guard let target = BackupService.iCloudBackupsDirectory() else {
+            backupMessage = "iCloud Drive が利用できません。iCloud にサインインして iCloud Drive を有効にしてください。"
+            return
+        }
+        isRunningBackup = true
+        let service = BackupService(
+            exporter: ExportService(context: modelContext),
+            targetDirectory: target
+        )
+        do {
+            let url = try service.performBackup()
+            backupMessage = "バックアップしました: \(url.lastPathComponent)"
+        } catch {
+            backupMessage = error.localizedDescription
+        }
+        isRunningBackup = false
+    }
+
+    func reseedTemplates() {
+        do {
+            try AppModelContainer.reseedDefaultTemplates(in: modelContext)
+            reseedMessage = "デフォルトテンプレートを追加しました (既存の同名テンプレはそのまま)"
+        } catch {
+            reseedMessage = error.localizedDescription
+        }
+    }
+}

--- a/ios/DailyLog/Views/Settings/SettingsView.swift
+++ b/ios/DailyLog/Views/Settings/SettingsView.swift
@@ -2,18 +2,21 @@ import SwiftData
 import SwiftUI
 
 struct SettingsView: View {
-    @Environment(\.modelContext) private var modelContext
+    @Environment(\.modelContext) var modelContext
 
-    @AppStorage(AppPreferences.Keys.iCloudSyncEnabled) private var iCloudSyncEnabled = false
-    @AppStorage(AppPreferences.Keys.notificationsEnabled) private var notificationsEnabled = true
+    @AppStorage(AppPreferences.Keys.iCloudSyncEnabled) var iCloudSyncEnabled = false
+    @AppStorage(AppPreferences.Keys.notificationsEnabled) var notificationsEnabled = true
 
-    @State private var reseedConfirmation = false
-    @State private var reseedMessage: String?
-    @State private var isExporting = false
-    @State private var exportArchive: ExportArchive?
-    @State private var exportErrorMessage: String?
-    @State private var backupMessage: String?
-    @State private var isRunningBackup = false
+    @State var reseedConfirmation = false
+    @State var reseedMessage: String?
+    @State var isExporting = false
+    @State var exportArchive: ExportArchive?
+    @State var exportErrorMessage: String?
+    @State var backupMessage: String?
+    @State var isRunningBackup = false
+    @State var isPresentingImporter = false
+    @State var pendingImportURL: URL?
+    @State var importMessage: String?
 
     var body: some View {
         NavigationStack {
@@ -72,46 +75,50 @@ struct SettingsView: View {
             } message: { message in
                 Text(message)
             }
+            .fileImporter(
+                isPresented: $isPresentingImporter,
+                allowedContentTypes: [.zip],
+                allowsMultipleSelection: false
+            ) { result in
+                handleImportSelection(result)
+            }
+            .confirmationDialog(
+                "復元方法を選んでください",
+                isPresented: Binding(
+                    get: { pendingImportURL != nil },
+                    set: { if !$0 { pendingImportURL = nil } }
+                ),
+                titleVisibility: .visible,
+                presenting: pendingImportURL
+            ) { url in
+                Button("マージ (既存データ保持)") {
+                    performImport(url: url, mode: .merge)
+                }
+                Button("完全置換", role: .destructive) {
+                    performImport(url: url, mode: .replace)
+                }
+                Button("キャンセル", role: .cancel) {
+                    pendingImportURL = nil
+                }
+            } message: { _ in
+                Text("マージは既存データを保ちつつ追加、完全置換は既存を削除してから復元します。復元後はアプリの再起動を推奨します。")
+            }
+            .alert(
+                "インポート",
+                isPresented: Binding(
+                    get: { importMessage != nil },
+                    set: { if !$0 { importMessage = nil } }
+                ),
+                presenting: importMessage
+            ) { _ in
+                Button("OK", role: .cancel) { importMessage = nil }
+            } message: { message in
+                Text(message)
+            }
         }
     }
 
-    private func export() {
-        isExporting = true
-        do {
-            let service = ExportService(context: modelContext)
-            let url = try service.makeArchive()
-            exportArchive = ExportArchive(url: url)
-        } catch {
-            exportErrorMessage = error.localizedDescription
-        }
-        isExporting = false
-    }
-
-    private func cleanupExportArchive() {
-        if let archive = exportArchive {
-            try? FileManager.default.removeItem(at: archive.url)
-            exportArchive = nil
-        }
-    }
-
-    private func runManualBackup() {
-        guard let target = BackupService.iCloudBackupsDirectory() else {
-            backupMessage = "iCloud Drive が利用できません。iCloud にサインインして iCloud Drive を有効にしてください。"
-            return
-        }
-        isRunningBackup = true
-        let service = BackupService(
-            exporter: ExportService(context: modelContext),
-            targetDirectory: target
-        )
-        do {
-            let url = try service.performBackup()
-            backupMessage = "バックアップしました: \(url.lastPathComponent)"
-        } catch {
-            backupMessage = error.localizedDescription
-        }
-        isRunningBackup = false
-    }
+    // アクション実装は SettingsView+Actions.swift にある。
 
     private var syncSection: some View {
         Section("同期") {
@@ -158,8 +165,11 @@ struct SettingsView: View {
             }
             .disabled(isExporting)
 
-            LabeledContent("インポート", value: "Issue #23 で実装")
-                .foregroundStyle(.secondary)
+            Button {
+                isPresentingImporter = true
+            } label: {
+                Label("インポート / 復元", systemImage: "square.and.arrow.down")
+            }
 
             Button {
                 runManualBackup()
@@ -180,15 +190,6 @@ struct SettingsView: View {
         Section("このアプリ") {
             LabeledContent("バージョン", value: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "-")
             LabeledContent("ビルド", value: Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "-")
-        }
-    }
-
-    private func reseedTemplates() {
-        do {
-            try AppModelContainer.reseedDefaultTemplates(in: modelContext)
-            reseedMessage = "デフォルトテンプレートを追加しました (既存の同名テンプレはそのまま)"
-        } catch {
-            reseedMessage = error.localizedDescription
         }
     }
 }

--- a/ios/DailyLogTests/ImportServiceTests.swift
+++ b/ios/DailyLogTests/ImportServiceTests.swift
@@ -1,0 +1,99 @@
+@testable import DailyLog
+import SwiftData
+import XCTest
+
+@MainActor
+final class ImportServiceTests: XCTestCase {
+    private var sourceContainer: ModelContainer!
+    private var destinationContainer: ModelContainer!
+    private var tempRoot: URL!
+    private var sourceStorage: PhotoStorage!
+    private var destinationStorage: PhotoStorage!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sourceContainer = try AppModelContainer.makeContainer(inMemory: true)
+        destinationContainer = try AppModelContainer.makeContainer(inMemory: true)
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ImportServiceTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        sourceStorage = PhotoStorage(rootURL: tempRoot.appendingPathComponent("src-photos"))
+        destinationStorage = PhotoStorage(rootURL: tempRoot.appendingPathComponent("dst-photos"))
+    }
+
+    override func tearDownWithError() throws {
+        if let tempRoot {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+        destinationStorage = nil
+        sourceStorage = nil
+        tempRoot = nil
+        destinationContainer = nil
+        sourceContainer = nil
+        try super.tearDownWithError()
+    }
+
+    func testImportIntoEmptyContainerMergeMode() throws {
+        let templateID = UUID()
+        let activityID = UUID()
+
+        let sourceContext = sourceContainer.mainContext
+        let template = ActivityTemplate(id: templateID, name: "仕事", iconName: "briefcase.fill")
+        sourceContext.insert(template)
+        let activity = Activity(id: activityID, template: template, startAt: Date(timeIntervalSince1970: 1_700_000_000))
+        sourceContext.insert(activity)
+        try sourceContext.save()
+
+        let archive = try ExportService(context: sourceContext, storage: sourceStorage).makeArchive()
+        defer { try? FileManager.default.removeItem(at: archive) }
+
+        let importer = ImportService(context: destinationContainer.mainContext, storage: destinationStorage)
+        let result = try importer.importArchive(at: archive, mode: .merge)
+
+        XCTAssertEqual(result.templatesImported, 1)
+        XCTAssertEqual(result.activitiesImported, 1)
+
+        let destTemplates = try destinationContainer.mainContext.fetch(FetchDescriptor<ActivityTemplate>())
+        let destActivities = try destinationContainer.mainContext.fetch(FetchDescriptor<Activity>())
+        XCTAssertEqual(destTemplates.map(\.id), [templateID])
+        XCTAssertEqual(destActivities.map(\.id), [activityID])
+        XCTAssertEqual(destActivities.first?.template?.id, templateID)
+    }
+
+    func testImportReplaceModeDeletesPreexistingRecords() throws {
+        let destContext = destinationContainer.mainContext
+        destContext.insert(ActivityTemplate(name: "残ると困る"))
+        try destContext.save()
+
+        // Empty source
+        let emptyArchive = try ExportService(context: sourceContainer.mainContext, storage: sourceStorage).makeArchive()
+        defer { try? FileManager.default.removeItem(at: emptyArchive) }
+
+        let importer = ImportService(context: destContext, storage: destinationStorage)
+        _ = try importer.importArchive(at: emptyArchive, mode: .replace)
+
+        let remaining = try destContext.fetch(FetchDescriptor<ActivityTemplate>())
+        XCTAssertTrue(remaining.isEmpty, "replace mode should wipe pre-existing templates")
+    }
+
+    func testImportUpdatesExistingTemplateByID() throws {
+        let templateID = UUID()
+        let destContext = destinationContainer.mainContext
+        destContext.insert(ActivityTemplate(id: templateID, name: "旧名"))
+        try destContext.save()
+
+        let sourceContext = sourceContainer.mainContext
+        sourceContext.insert(ActivityTemplate(id: templateID, name: "新名"))
+        try sourceContext.save()
+
+        let archive = try ExportService(context: sourceContext, storage: sourceStorage).makeArchive()
+        defer { try? FileManager.default.removeItem(at: archive) }
+
+        let importer = ImportService(context: destContext, storage: destinationStorage)
+        _ = try importer.importArchive(at: archive, mode: .merge)
+
+        let templates = try destContext.fetch(FetchDescriptor<ActivityTemplate>())
+        XCTAssertEqual(templates.count, 1)
+        XCTAssertEqual(templates.first?.name, "新名")
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -17,6 +17,11 @@ settings:
     ENABLE_USER_SCRIPT_SANDBOXING: YES
     SWIFT_STRICT_CONCURRENCY: complete
 
+packages:
+  ZIPFoundation:
+    url: https://github.com/weichsel/ZIPFoundation
+    from: 0.9.19
+
 targets:
   DailyLog:
     type: application
@@ -42,6 +47,7 @@ targets:
         INFOPLIST_KEY_NSSupportsLiveActivities: YES
     dependencies:
       - target: DailyLogWidget
+      - package: ZIPFoundation
 
   DailyLogTests:
     type: bundle.unit-test


### PR DESCRIPTION
## Summary
エクスポート ZIP から SwiftData を復元。マージ/完全置換を選択、写真も App Group ストレージに戻す。

### 依存追加
- **ZIPFoundation** SPM (https://github.com/weichsel/ZIPFoundation)
  - iOS SDK 標準に unzip API が無いため追加
  - エクスポート側は NSFileCoordinator で zip 作成なので依存不要、インポート側だけ使う

### ImportService
- `importArchive(at:mode:)`: temp dir に解凍 → `data.json` を探索 → `ExportSnapshot` decode → schemaVersion 検証 → replace モードなら全削除 → upsert → 写真復元 → `save`
- 親子関係は ID 辞書で第 2 パスに再結線
- `applySnapshot` を templates/activities/meals/settings の 4 関数に分割 (function_body_length)
- `restorePhotos` が `photos/*.jpg` を `PhotoStorage.saveJPEGPreservingFilename` で保存 (ファイル名維持で meal.photoFilenames の参照が切れない)
- エラー: `missingDataJSON`, `unsupportedSchemaVersion(Int)`

### UI
- 設定の "インポート / 復元" → `.fileImporter(contentTypes: [.zip])`
- `startAccessingSecurityScopedResource` でサンドボックス外の選択も対応
- confirmationDialog: マージ / 完全置換 / キャンセル
- 結果を multi-line alert で表示 (件数 + 再起動推奨)
- `SettingsView` の type_body_length 回避のため action 関数は `SettingsView+Actions.swift` に分離

## Tests (+3 / 71 total)
- 空 destination にマージ: ID 保持 + テンプレ↔Activity 再結線
- 完全置換: 既存ゼロ化
- マージで既存テンプレ ID を更新 (重複しない)
- export → import の往復を実 `ExportService` 出力で検証

## Verification (local)
- [x] `swiftformat --lint` / `swiftlint --strict` clean
- [x] `make -C ios build` SUCCEEDED
- [x] `make -C ios test` 71/71 passed

Closes #23