### PR TITLE
TASK-4: docs/textbook 採用技術メモ + plan.md 再生成

### DIFF
--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,90 @@
+# DailyLog 実装計画
+
+行動記録と食事記録を日常的にキャプチャする iOS アプリ。
+
+## 目的
+
+- 数タップで今やっている行動の開始/停止を記録する
+- 食事は写真 + 店舗情報付きで残す
+- 日単位/週単位の振り返りを素早くできる
+- iCloud 同期 + ローカルのエクスポート/復元で端末変更に耐える
+
+## 技術スタック
+
+| 領域 | 採用 |
+|---|---|
+| 言語 | Swift 5.9+ |
+| UI | SwiftUI |
+| 永続化 | SwiftData (+ CloudKit `.automatic` オプション切替) |
+| チャート | Swift Charts (`SectorMark`, `RectangleMark`, `BarMark`) |
+| 音声入力 | SFSpeechRecognizer + AVAudioEngine |
+| ウィジェット | WidgetKit (Static + ActivityKit Live) |
+| Live Activity | ActivityKit (Lock / Dynamic Island) |
+| 写真 | PhotosUI `PhotosPicker` + `UIImagePickerController` |
+| ZIP | エクスポート側 `NSFileCoordinator(.forUploading)`、インポート側 [ZIPFoundation](https://github.com/weichsel/ZIPFoundation) |
+| 通知 | UserNotifications (ローカル) |
+| 背景処理 | BGTaskScheduler (バックアップ、将来追加予定) |
+| プロジェクト生成 | [xcodegen](https://github.com/yonaskolb/XcodeGen) |
+| Lint / Format | SwiftLint + SwiftFormat |
+| CI | GitHub Actions (macos-latest, DerivedData cache) |
+
+## 画面構成
+
+```
+MainTabView
+├── ホーム (HomeView)
+│   ├── InProgressCard (進行中 + mic + 食事アイコン + 停止)
+│   └── TemplateGrid (ルートテンプレ, 長押しで ChildTemplateSheet)
+├── カレンダー (CalendarView / UICalendarView wrapper)
+│   └── DayDetailView (記録一覧 + 円グラフ)
+├── 統計 (StatsView)
+│   ├── WeekChartView (24h × 7曜日 RectangleMark)
+│   └── PeriodStatsView (週/月切替, BarMark, 食事サマリー)
+└── 設定 (SettingsView)
+    ├── iCloud 同期トグル
+    ├── 通知マスタートグル
+    ├── デフォルトテンプレ再追加
+    ├── エクスポート
+    ├── インポート / 復元
+    ├── iCloud Drive バックアップ
+    └── バージョン表示
+```
+
+## モデル
+
+- **ActivityTemplate**: 名前 / アイコン / カラー / sortOrder / reminderMinutes / isMealType / parent / children
+- **Activity**: startAt / endAt / note / voiceNoteFilename / voiceTranscript / template / meal
+- **Meal**: photoFilenames[] / shopName / shopAddress / note / activity
+- **AppSettings**: iCloudSyncEnabled / defaultReminderMinutes (主にエクスポート往復用, 動作切替は `AppPreferences` UserDefaults 経由)
+
+## サービス
+
+- **ActivityService** - start/stop + 通知 + ウィジェット snapshot + Live Activity 連携
+- **TemplateService** - create/reorder/delete, 自動 sortOrder
+- **ActivityNotifier / LocalNotificationNotifier** - 忘れアラート
+- **LiveActivityController** - ActivityKit 開始/終了
+- **SpeechRecognitionService** - 音声メモ
+- **PhotoStorage** - App Group 下の写真保存
+- **ExportService / ImportService / BackupService** - データ往復
+
+## 識別子
+
+| 種別 | 値 |
+|---|---|
+| App Bundle ID | `com.coco.daily-log` |
+| Widget Bundle ID | `com.coco.daily-log.widget` |
+| Tests Bundle ID | `com.coco.daily-log.tests` |
+| App Group | `group.com.coco.daily-log` |
+| iCloud Container | `iCloud.com.coco.daily-log` |
+
+## 進捗 (2026-04-25 時点)
+
+全 priority:high + priority:medium + priority:low の実装を完了。残件:
+
+- `#13` Core ML による食事検出 (`future` ラベル、保留)
+- `#24` Apple Developer Portal 手動設定 (`needs:human`)
+- BGAppRefreshTask による自動 iCloud バックアップ (#22 のフォローアップ)
+
+## 開発フロー
+
+`CLAUDE.md` を参照。1 issue → 1 feature branch → PR → CI 緑 → squash merge。

--- a/docs/textbook/photos-and-files.md
+++ b/docs/textbook/photos-and-files.md
@@ -1,0 +1,137 @@
+# 写真選択とファイル入出力
+
+## 1. PhotosPicker (iOS 16+ SwiftUI ネイティブ)
+
+ライブラリから選択する UI。複数枚、動画フィルタ、`.images` / `.videos` フィルタ対応。
+
+```swift
+@State private var selection: [PhotosPickerItem] = []
+
+PhotosPicker(selection: $selection, maxSelectionCount: 4, matching: .images) {
+    Text("ライブラリから選択")
+}
+.onChange(of: selection) { _, items in
+    Task {
+        for item in items {
+            if let data = try? await item.loadTransferable(type: Data.self),
+               let image = UIImage(data: data) {
+                save(image)
+            }
+        }
+    }
+}
+```
+
+- `loadTransferable` は非同期で、HEIC を JPEG に変換しながら読める
+- 選択後に `selection` を空配列に戻さないと、同じ画像再選択が `onChange` を発火しない
+
+## 2. カメラ撮影 (UIImagePickerController)
+
+SwiftUI にネイティブ代替が無いので `UIViewControllerRepresentable` で包む。
+
+```swift
+struct CameraPicker: UIViewControllerRepresentable {
+    let onPicked: (UIImage) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onPicked: onPicked, dismiss: { dismiss() })
+    }
+
+    final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        // didFinishPickingMediaWithInfo, imagePickerControllerDidCancel
+    }
+
+    static var isCameraAvailable: Bool {
+        UIImagePickerController.isSourceTypeAvailable(.camera)
+    }
+}
+```
+
+simulator はカメラ無しなので `.fullScreenCover` に出すときは `isCameraAvailable` で制御。
+
+## 3. App Group ファイル領域
+
+本アプリは食事写真をウィジェットからも参照できるよう、App Group コンテナに保存。
+
+```swift
+guard let container = FileManager.default.containerURL(
+    forSecurityApplicationGroupIdentifier: "group.com.coco.daily-log"
+) else { return nil }
+let photosDir = container.appendingPathComponent("Photos", isDirectory: true)
+```
+
+- エンタイトルメントで `com.apple.security.application-groups` を設定済みでないと nil
+- シミュレータは `/Users/.../Containers/Shared/AppGroup/.../Photos/*.jpg` の実パスに解決される
+
+## 4. iCloud Drive (ubiquity container)
+
+ユーザーが Files アプリから見える領域。
+
+```swift
+guard let iCloud = FileManager.default.url(
+    forUbiquityContainerIdentifier: "iCloud.com.coco.daily-log"
+) else { return nil }
+let backups = iCloud.appendingPathComponent("Documents/Backups")
+```
+
+- 「iCloud にサインイン + iCloud Drive ON」の端末でのみ non-nil
+- `Documents/` 配下が Files アプリのアプリフォルダーに相当
+- 書き込み後、iCloud 同期は OS 任せ (ネット接続と省電力ポリシー次第で遅延)
+
+## 5. ファイル選択 / 保存
+
+### 選択
+
+`.fileImporter(isPresented: allowedContentTypes:)` で Files アプリから選ばせる。
+
+```swift
+.fileImporter(
+    isPresented: $isPresentingImporter,
+    allowedContentTypes: [.zip],
+    allowsMultipleSelection: false
+) { result in
+    handleImportSelection(result)
+}
+```
+
+- `startAccessingSecurityScopedResource()` を忘れると iCloud Drive / iOS の他アプリディレクトリを読めない
+- 選んだ URL はすぐアクセスが切れる場合があるので、temp にコピーしてから処理
+
+### 保存
+
+`UIActivityViewController` を SwiftUI に持ち込む:
+
+```swift
+struct ShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+    func updateUIViewController(_ vc: UIActivityViewController, context: Context) {}
+}
+```
+
+ZIP の URL を渡せば Files アプリ / AirDrop / メール等で保存できる。
+
+## 6. ZIP 操作
+
+- **作成**: `NSFileCoordinator.coordinate(readingItemAt:options: [.forUploading])` のクロージャで一時 ZIP URL が渡される。ディレクトリ指定すると zip 圧縮、ファイル指定すると安定コピー
+- **展開**: iOS SDK に無いため [ZIPFoundation](https://github.com/weichsel/ZIPFoundation) SPM を追加。`FileManager.default.unzipItem(at:to:)` 拡張が提供される
+
+```swift
+try FileManager.default.unzipItem(at: zipURL, to: destination)
+```
+
+## 注意
+
+- 写真は HEIC で保存されがち。JPEG 化しないと他アプリで開けない端末もある → `UIImage.jpegData(compressionQuality:)`
+- App Group / iCloud のパスはどちらもエンタイトルメント未設定だと `nil` になる。UI は「利用不可」プロンプトを用意
+- `contentsOfDirectory` が返す URL は順不同。ソートはクライアント側で行う

--- a/docs/textbook/speech-recognition.md
+++ b/docs/textbook/speech-recognition.md
@@ -1,0 +1,108 @@
+# 音声メモ (Speech + AVAudioEngine)
+
+`SFSpeechRecognizer` に `AVAudioEngine` のマイク入力をストリーミングして、進行中の Activity にテキストメモを追記する。
+
+## 1. 権限
+
+2 種類の権限が要る。`Info.plist` と 2 つ:
+
+- `NSMicrophoneUsageDescription`
+- `NSSpeechRecognitionUsageDescription`
+
+iOS 17 からマイク許可は `AVAudioApplication.requestRecordPermission()` に一本化されている (古い `AVAudioSession.requestRecordPermission` は Deprecated)。
+
+```swift
+static func requestAuthorization() async -> Bool {
+    let speech = await withCheckedContinuation { cont in
+        SFSpeechRecognizer.requestAuthorization { cont.resume(returning: $0) }
+    }
+    guard speech == .authorized else { return false }
+    return await AVAudioApplication.requestRecordPermission()
+}
+```
+
+## 2. 認識パイプライン
+
+```swift
+final class SpeechRecognitionService: ObservableObject {
+    @Published private(set) var transcription = ""
+    @Published private(set) var isRecording = false
+
+    private let recognizer = SFSpeechRecognizer(locale: Locale(identifier: "ja-JP"))
+    private let audioEngine = AVAudioEngine()
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var task: SFSpeechRecognitionTask?
+
+    func startRecording() throws {
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try session.setActive(true, options: .notifyOthersOnDeactivation)
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        request.requiresOnDeviceRecognition = recognizer?.supportsOnDeviceRecognition ?? false
+        self.request = request
+
+        let input = audioEngine.inputNode
+        let format = input.outputFormat(forBus: 0)
+        input.installTap(onBus: 0, bufferSize: 1024, format: format) { buffer, _ in
+            request.append(buffer)
+        }
+
+        audioEngine.prepare()
+        try audioEngine.start()
+        isRecording = true
+
+        task = recognizer?.recognitionTask(with: request) { [weak self] result, error in
+            guard let self else { return }
+            Task { @MainActor in
+                if let result {
+                    self.transcription = result.bestTranscription.formattedString
+                }
+                if error != nil { self.stop() }
+            }
+        }
+    }
+
+    func stop() {
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        request?.endAudio()
+        task?.finish()
+        request = nil
+        task = nil
+        isRecording = false
+    }
+}
+```
+
+ポイント:
+
+- `shouldReportPartialResults = true` でストリーミング中の途中結果を表示
+- `.measurement` モードは音声認識で推奨 (ノイズ抑制などの前処理が弱く、認識精度が出る)
+- `installTap(onBus:bufferSize:format:)` にブロックが渡って、マイクバッファが次々届く → `request.append(buffer)` へ流す
+- SFSpeechRecognizer の delegate メソッドは別スレッドから呼ばれることがあるので `Task { @MainActor in ... }` で必ず UI 更新
+
+## 3. UI 側 (本アプリ)
+
+`VoiceMemoSheet` は 3 状態を持つ:
+
+- `.checking`: 権限リクエスト中の `ProgressView`
+- `.denied`: 「設定アプリから権限を許可してください」案内
+- `.authorized`: 録音中ドット + 認識テキスト + 停止/追加ボタン
+
+確定時は `Activity.appendNote(transcription)` でモデルに追記。
+
+## 4. テスト
+
+SFSpeechRecognizer はマイク + 権限を必要とするため XCTest で完全には再現できない。本アプリでは:
+
+- 純粋ロジック (`Activity.appendNote` の空判定・改行連結) のみ単体テスト
+- 録音/認識部分は実機/シミュレータの手動検証
+
+## 注意
+
+- `AVAudioSession.setCategory(.record, ...)` の後に `audioEngine.start()` しないと音が取れない
+- 他アプリが `.playback` を握っている状態で `.record` に切り替えると一瞬音が途切れる。`.duckOthers` / `.mixWithOthers` で挙動を選択
+- On-device recognition は一部ロケールのみ対応 (`recognizer.supportsOnDeviceRecognition` で判定)
+- 長時間録音時はサーバー側 recognition で途切れる場合がある (1 分程度を目安に区切る設計も検討)

--- a/docs/textbook/swift-charts.md
+++ b/docs/textbook/swift-charts.md
@@ -1,0 +1,108 @@
+# Swift Charts
+
+Apple が iOS 16 で導入したネイティブチャート。SwiftUI の ResultBuilder で Chart を書く。本アプリでは `SectorMark` (円グラフ) / `RectangleMark` (週 24h) / `BarMark` (カテゴリ別) を使用。
+
+## 1. `SectorMark` - 日別円グラフ
+
+```swift
+Chart {
+    ForEach(slices) { slice in
+        SectorMark(
+            angle: .value("時間", slice.totalSeconds),
+            innerRadius: .ratio(0.55),
+            angularInset: 1
+        )
+        .foregroundStyle(Color(hex: slice.colorHex) ?? .accentColor)
+        .cornerRadius(4)
+    }
+}
+.chartLegend(.hidden)
+```
+
+- `innerRadius: .ratio(0.55)` でドーナツ化
+- `angularInset` でセクター間にスペース
+- `.chartLegend(.hidden)` して自前の凡例ビューを用意するとタップでハイライトなどカスタムしやすい
+
+## 2. `RectangleMark` - 週 24h グリッド
+
+```swift
+Chart {
+    ForEach(spans) { span in
+        RectangleMark(
+            xStart: .value("start-day", Double(span.weekdayIndex) - 0.4),
+            xEnd: .value("end-day", Double(span.weekdayIndex) + 0.4),
+            yStart: .value("start-hour", span.startHours),
+            yEnd: .value("end-hour", span.endHours)
+        )
+        .foregroundStyle(Color(hex: span.colorHex) ?? .accentColor)
+    }
+}
+.chartXScale(domain: -0.5...6.5)
+.chartYScale(domain: 0.0...24.0)
+.chartXAxis {
+    AxisMarks(values: Array(0..<7).map(Double.init)) { value in
+        AxisValueLabel { weekdayLabel(for: value) }
+    }
+}
+```
+
+- `xStart/xEnd` + `yStart/yEnd` で矩形の 4 頂点を指定
+- X 軸に曜日、Y 軸に時間帯 (0-24) の割付が直感的
+- 曜日ラベルを自前で `@ViewBuilder` に出さないとコンパイラが落ちる (SwiftUI の複雑度爆発回避)
+
+## 3. `BarMark` - 横棒ランキング
+
+```swift
+Chart {
+    ForEach(categories) { category in
+        BarMark(
+            x: .value("時間", category.totalSeconds / 3600),
+            y: .value("カテゴリ", category.templateName)
+        )
+        .foregroundStyle(Color(hex: category.colorHex) ?? .accentColor)
+        .annotation(position: .trailing, alignment: .leading) {
+            Text(DurationFormatter.elapsed(seconds: Int(category.totalSeconds)))
+                .font(.caption2)
+        }
+    }
+}
+.chartYAxis { AxisMarks(position: .leading) }
+```
+
+- `annotation` でバーの端に値ラベルを重ねる
+- カテゴリ軸を y 側にすると「ランキング」らしく縦に並ぶ
+
+## 4. 軸のカスタム
+
+```swift
+.chartYAxis {
+    AxisMarks(values: [0.0, 6.0, 12.0, 18.0, 24.0]) { value in
+        AxisGridLine()
+        AxisTick()
+        AxisValueLabel {
+            if let hour = value.as(Double.self) {
+                Text(String(format: "%02d:00", Int(hour)))
+            }
+        }
+    }
+}
+```
+
+- `values:` に固定配列で指定すると好きな目盛を出せる
+- `.automatic` と違って決め打ちの罫線と値が出るので読みやすい
+
+## 5. `chartPlotStyle`
+
+チャートの背景を調整したいときに。
+
+```swift
+.chartPlotStyle { plot in
+    plot.background(RoundedRectangle(cornerRadius: 8).fill(Color(.secondarySystemBackground)))
+}
+```
+
+## 注意
+
+- `LineMark` など時系列チャートでは `.value("x", date)` を Date で渡すと自動で Date 軸になる
+- X/Y に Double 値を渡すときは `-chartXScale(domain:)` を必ず書いておくと意図通りに収まる
+- アクセシビリティ向けに `.accessibilityLabel(_:)` を各 Mark に付けるとスクリーンリーダー対応

--- a/docs/textbook/swiftdata.md
+++ b/docs/textbook/swiftdata.md
@@ -1,0 +1,114 @@
+# SwiftData
+
+Apple が iOS 17 で導入した宣言的な永続化フレームワーク。Core Data の後継だが `@Model` マクロで Swift クラスをそのまま永続化できる。本アプリでは CloudKit 同期とも組み合わせている。
+
+## 本アプリでの使い方
+
+### モデル定義 (`@Model`)
+
+```swift
+@Model
+final class Activity {
+    var id: UUID = UUID()
+    var startAt: Date = Date()
+    var endAt: Date?
+    var note: String = ""
+    var template: ActivityTemplate?
+
+    @Relationship(deleteRule: .cascade, inverse: \Meal.activity)
+    var meal: Meal?
+}
+```
+
+- `@Model` で自動的に `PersistentModel` 適合とストレージ属性が付与される
+- `@Relationship(deleteRule:inverse:)` で一方の側に書けば逆辺は推論される
+- **CloudKit 互換**: すべての stored property にデフォルト値があること、`@Attribute(.unique)` を使わないこと
+
+### ModelContainer の構成
+
+```swift
+let configuration = ModelConfiguration(
+    schema: schema,
+    isStoredInMemoryOnly: inMemory,
+    cloudKitDatabase: AppPreferences.iCloudSyncEnabled ? .automatic : .none
+)
+let container = try ModelContainer(for: schema, configurations: configuration)
+```
+
+- `.automatic`: エンタイトルメントの iCloud コンテナを使う
+- `.none`: ローカルのみ (テストでは `isStoredInMemoryOnly: true` と組合せ)
+
+アプリのトップで:
+
+```swift
+WindowGroup { MainTabView() }
+    .modelContainer(modelContainer)
+```
+
+### 取得 (`@Query`)
+
+View 側で宣言的に取得。変更は自動で再レンダリング。
+
+```swift
+@Query(
+    filter: #Predicate<Activity> { $0.endAt == nil },
+    sort: \Activity.startAt,
+    order: .reverse
+)
+private var inProgressActivities: [Activity]
+```
+
+- `#Predicate` は型安全、クローズしか受け付けない制限がある (外部変数キャプチャに注意)
+- `@Query` は View の再計算に連動する
+
+### 明示的な操作 (`ModelContext`)
+
+サービス層では `ModelContext` を直接使う。
+
+```swift
+@MainActor
+struct ActivityService {
+    let context: ModelContext
+
+    func start(template: ActivityTemplate) throws {
+        let activity = Activity(template: template, startAt: Date())
+        context.insert(activity)
+        try context.save()
+    }
+
+    func fetchInProgress() throws -> [Activity] {
+        let descriptor = FetchDescriptor<Activity>(
+            predicate: #Predicate { $0.endAt == nil },
+            sortBy: [SortDescriptor(\.startAt)]
+        )
+        return try context.fetch(descriptor)
+    }
+}
+```
+
+- `save()` を忘れると永続化されない
+- `SortDescriptor` / `FetchDescriptor` は Foundation の API と同じ形
+
+### テスト
+
+`isStoredInMemoryOnly: true` の `ModelContainer` を `setUpWithError` で作る。CloudKit はテストでは `.none` 固定。
+
+```swift
+override func setUpWithError() throws {
+    container = try AppModelContainer.makeContainer(inMemory: true)
+    service = ActivityService(context: container.mainContext, notifier: MockNotifier())
+}
+```
+
+## ハマり所
+
+- **`@Attribute(.unique)` は CloudKit と併用不可**: schema 作成時にエラー。UUID を自前で振るしかない
+- **nil 比較 `#Predicate`**: `#Predicate { $0.endAt == nil }` は OK、`$0.endAt != capturedVar` のような外部参照は不可
+- **スレッド**: SwiftData モデルは Main Actor 前提。バックグラウンド Task からアクセスすると警告/クラッシュ
+- **`@Model` クラスは Sendable ではない**: 別アクターに渡すときは ID 等の値型を抜き出してから渡す
+- **マイグレーション**: `.unique` 不使用 + 全プロパティ default 値なら、ほとんどの追加はマイグレーションなしで済む
+
+## 参考
+
+- [Apple Docs: SwiftData](https://developer.apple.com/documentation/swiftdata)
+- [WWDC23 Meet SwiftData](https://developer.apple.com/videos/play/wwdc2023/10187/)

--- a/docs/textbook/swiftui.md
+++ b/docs/textbook/swiftui.md
@@ -1,0 +1,107 @@
+# SwiftUI パターン集 (本アプリで使ったもの)
+
+## 1. 画面ナビゲーション
+
+- `NavigationStack { ... }` でルートを用意し、`NavigationLink`, `.navigationDestination(for:)`, `.navigationDestination(item:)` で遷移
+- シートは `.sheet(isPresented:)` と `.sheet(item:)` を使い分ける。`item:` 版は `Identifiable` を受け取り、nil で自動クローズ
+- タブ切替は `TabView { … .tabItem { Label(...) } }`
+
+```swift
+TabView {
+    HomeView().tabItem { Label("ホーム", systemImage: "clock") }
+    CalendarView().tabItem { Label("カレンダー", systemImage: "calendar") }
+    StatsView().tabItem { Label("統計", systemImage: "chart.bar") }
+    SettingsView().tabItem { Label("設定", systemImage: "gear") }
+}
+```
+
+## 2. @State と @Environment
+
+- View 内部の短命な状態は `@State`
+- ModelContext のようなシステム注入は `@Environment(\.modelContext) private var modelContext`
+- `@AppStorage` は `UserDefaults.standard` (or suite) を直接バインドする。同期トグルや軽量設定に
+
+```swift
+@AppStorage("pref.iCloudSyncEnabled") private var iCloudSyncEnabled = false
+```
+
+## 3. コンパイラが重い body を避ける
+
+SwiftUI ビルダーは型が非常に太くなりやすく、`The compiler is unable to type-check this expression in reasonable time` が出やすい。
+
+対策:
+
+- ネストした条件 (`if ... { ... } else ...`) はサブビューに切り出す
+- `Background(alignment:)` + `Overlay(alignment:)` の中で条件分岐する場合は、`@ViewBuilder` プロパティに出す
+- `Button(action:) { ... }` を多重ネストする箇所は `{ action } label: { label }` のトレーリングクロージャ 2 つ形式にする
+
+```swift
+Button {
+    start()
+} label: {
+    Label("開始", systemImage: "play.fill")
+}
+```
+
+## 4. 破壊的操作の確認
+
+- `.confirmationDialog(titleVisibility: .visible)` で iOS 風 UI
+- `Button(role: .destructive, action:) { Text("削除") }` で色が自動で変わる
+
+## 5. 非同期 `.task`
+
+初回表示時に権限要求などをやりたいときは `.task { await ... }` を使う。cancel は View の life-cycle と連動。
+
+```swift
+.task {
+    await LocalNotificationNotifier.shared.requestAuthorizationIfNeeded()
+}
+```
+
+## 6. UIKit ブリッジ (`UIViewRepresentable`)
+
+- `UIImagePickerController` は SwiftUI にネイティブ代替が無い (カメラ撮影用)
+- `UICalendarView` も同様
+
+```swift
+struct CameraPicker: UIViewControllerRepresentable {
+    let onPicked: (UIImage) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    func makeUIViewController(context: Context) -> UIImagePickerController { ... }
+    func makeCoordinator() -> Coordinator { ... }
+}
+```
+
+Coordinator で delegate を実装し、親の closure へ結果を渡す。
+
+## 7. ファイル関連
+
+- `.fileImporter(isPresented:allowedContentTypes:)` - アプリ外の zip / json を選択
+- `UIActivityViewController` を `UIViewControllerRepresentable` でくるんだ `ShareSheet` で書き出し
+- `startAccessingSecurityScopedResource()` を忘れると Files アプリから拾ったファイルが読めない
+
+## 8. アラート
+
+`.alert(presenting:)` で `String?` optional を渡すとコンテンツに応じて自動で出る:
+
+```swift
+.alert(
+    "エラー",
+    isPresented: Binding(
+        get: { errorMessage != nil },
+        set: { if !$0 { errorMessage = nil } }
+    ),
+    presenting: errorMessage
+) { _ in
+    Button("OK", role: .cancel) {}
+} message: { msg in
+    Text(msg)
+}
+```
+
+## 9. タイマー更新
+
+`Text(date, style: .timer)` はシステムがチェック不要で秒更新してくれる。ウィジェットや Live Activity の timer 表示に最適 (timeline を増やさずに済む)。
+
+それ以外は `Timer.publish(every: 1, on: .main, in: .common).autoconnect()` を `.onReceive` で受ける。

--- a/docs/textbook/tooling.md
+++ b/docs/textbook/tooling.md
@@ -1,0 +1,120 @@
+# ツールチェーン (xcodegen / SwiftLint / SwiftFormat / GitHub Actions)
+
+本プロジェクトは macOS + Xcode 26.4 前提、Swift 5.9。ビルド・CI のセットアップを低コストに保つために 4 つのツールを組み合わせている。
+
+## 1. xcodegen
+
+`.xcodeproj` は **追跡しない** 。`ios/project.yml` から `xcodegen generate` で再生成する方針。
+
+利点:
+- マージコンフリクトが起きない
+- 追加ファイル/ターゲットの設定が YAML で diff できる
+- 個人の `xcuserdata/*` が混入しない
+
+基本形:
+```yaml
+name: DailyLog
+options:
+  bundleIdPrefix: com.coco
+  deploymentTarget:
+    iOS: "17.0"
+packages:
+  ZIPFoundation:
+    url: https://github.com/weichsel/ZIPFoundation
+    from: 0.9.19
+targets:
+  DailyLog:
+    type: application
+    platform: iOS
+    sources:
+      - path: DailyLog
+      - path: Shared
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.coco.daily-log
+        GENERATE_INFOPLIST_FILE: YES
+        INFOPLIST_KEY_NSSupportsLiveActivities: YES
+        CODE_SIGN_ENTITLEMENTS: DailyLog/DailyLog.entitlements
+    dependencies:
+      - target: DailyLogWidget
+      - package: ZIPFoundation
+```
+
+- `GENERATE_INFOPLIST_FILE: YES` + `INFOPLIST_KEY_*` で Info.plist の単純なキーを注入
+- `NSExtension` のような nested dict は手書きの Info.plist + `GENERATE_INFOPLIST_FILE: NO` に切り替える必要がある (本アプリでは Widget 側がこれ)
+- `Shared` を app と widget 両方の `sources` に入れるとコード共有できる
+
+## 2. SwiftLint
+
+`.swiftlint.yml` で設定。重要な opt-in:
+
+```yaml
+opt_in_rules:
+  - sorted_imports
+  - force_unwrapping
+  - explicit_init
+  - first_where
+  - redundant_nil_coalescing
+
+identifier_name:
+  min_length: 2
+
+trailing_comma:
+  mandatory_comma: true     # SwiftFormat の trailingCommas と合わせる
+```
+
+- `force_unwrapping` は `!` を強制エラーにする。代わりに `guard let ... else` / `throw` に倒すと堅くなる
+- `sorted_imports` は `import SwiftUI` の前後順を強制。`@testable import Foo` と `import Bar` の扱いは SwiftFormat の `--importgrouping` と揃える必要がある (本アプリは `alphabetized`)
+
+## 3. SwiftFormat
+
+`.swiftformat` に配置:
+
+```
+--swiftversion 5.9
+--indent 4
+--maxwidth 120
+--wraparguments before-first
+--wrapparameters before-first
+--wrapcollections before-first
+--self remove
+--importgrouping alphabetized
+```
+
+- `trailingCommas` ルール (SwiftFormat 0.61+) は **デフォルトで trailing comma を require** する。SwiftLint の `trailing_comma: mandatory_comma: true` と噛み合わせておく
+- `wrapPropertyBodies` ルール (0.61+) は `var id: String { rawValue }` のようなワンライナープロパティを multi-line に拡張する。local 0.60 と CI 0.62 で挙動が食い違うと CI だけ落ちるので、たまに `swiftformat --lint` を走らせて揃える
+
+## 4. GitHub Actions CI
+
+`.github/workflows/ci.yml`:
+
+- `macos-latest` ランナー
+- 2 ジョブを並列: `Lint / Format` と `Build & Test`
+- DerivedData を `actions/cache@v4` で `hashFiles('ios/project.yml', 'ios/**/*.swift')` をキーに保存。同一ブランチの 2 回目以降の push で incremental コンパイルが効く
+- `xcodebuild test` 一本で build → test を回す。build + test の 2 step は compile 重複で遅いので一本化
+- `-skipMacroValidation` / `-skipPackagePluginValidation` で interactive prompt を回避
+- `COMPILER_INDEX_STORE_ENABLE=NO` で IDE 用 index を作らず短縮
+
+実測:
+- 初回 (cache miss): 5-12 min
+- 同一 commit rerun (cache hit): 3-4 min
+
+## 5. ローカルコマンド
+
+```bash
+make -C ios generate      # project.yml から .xcodeproj 再生成
+make -C ios build         # iPhone シミュレータ向け Debug
+make -C ios test          # XCTest 実行
+make -C ios lint          # SwiftLint strict
+make -C ios format-check  # SwiftFormat dry-run
+make -C ios format        # SwiftFormat 適用
+make -C ios clean         # derived data 等削除
+```
+
+## 6. よくある詰まり所
+
+- **`xcode-select` が Command Line Tools を指している** → `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`
+- **`gh push` が OAuth workflow scope で拒否** → `gh auth refresh -s workflow`
+- **DateComponents に `isLeapMonth` が付く/付かない** の SDK 差で Set 等値判定が崩れる → 比較は `year/month/day` の triple のみで行う
+- **macOS runner 上の `Calendar.current` が UTC** → テスト用 Calendar は `TimeZone(identifier: "Asia/Tokyo")` を明示し、関数内で `calendar.timeZone = .current` のような上書きをしない (TASK-14 で踏んだ)
+- **public repo にすると macOS runner が無料になる** → private の場合は分数課金、billing 要注意

--- a/docs/textbook/widgetkit.md
+++ b/docs/textbook/widgetkit.md
@@ -1,0 +1,136 @@
+# WidgetKit + ActivityKit
+
+ホーム画面ウィジェットとロック画面/Dynamic Island の両方を、同じ `DailyLogWidget` app-extension ターゲットで提供している。
+
+## 1. ウィジェットバンドル
+
+```swift
+@main
+struct DailyLogWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        DailyLogWidget()           // ホーム画面ウィジェット
+        DailyLogLiveActivity()     // Live Activity
+    }
+}
+```
+
+Info.plist に `NSExtensionPointIdentifier = com.apple.widgetkit-extension` が要る。xcodegen の `INFOPLIST_KEY_*` では nested dict を注入できないため手書きの Info.plist (`ios/DailyLogWidget/Info.plist`) を置いている。
+
+## 2. ホーム画面ウィジェット (`StaticConfiguration`)
+
+```swift
+struct DailyLogWidget: Widget {
+    let kind: String = "DailyLogWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: DailyLogTimelineProvider()) { entry in
+            DailyLogWidgetEntryView(entry: entry)
+                .containerBackground(for: .widget) {
+                    entry.backgroundColor
+                }
+        }
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+```
+
+- `containerBackground(for: .widget)` は iOS 17 以降の必須 API (無いとウィジェットが描画されない)
+- Small / Medium サイズだけサポート (Lockscreen 用の `.accessory*` は現在無い)
+
+### TimelineProvider
+
+本アプリはアプリ側で App Group UserDefaults に `CurrentActivitySnapshot` を書き込み、ウィジェットがそれを読む単純モデル。
+
+```swift
+struct DailyLogTimelineProvider: TimelineProvider {
+    func getTimeline(in context: Context, completion: @escaping (Timeline<DailyLogEntry>) -> Void) {
+        let entry = DailyLogEntry(date: Date(), snapshot: CurrentActivitySnapshot.load())
+        let refresh = Calendar.current.date(byAdding: .minute, value: 15, to: Date())!
+        completion(Timeline(entries: [entry], policy: .after(refresh)))
+    }
+}
+```
+
+経過時間は `Text(startAt, style: .timer)` に任せているのでエントリを増やす必要がない。15 分毎の refresh は省電力のため。
+
+アプリ側で `WidgetCenter.shared.reloadAllTimelines()` を呼ぶと次回 timeline 取得で最新スナップショットが反映される。
+
+## 3. App Group データ共有
+
+- `project.yml` の `Shared` ディレクトリを両ターゲットの `sources` に追加してシンプルなコード共有
+- `UserDefaults(suiteName: "group.com.coco.daily-log")` に JSON エンコードした `Codable` を置く
+- SwiftData ストアをウィジェットに共有する方法もあるが、コンテナ初期化コストが重いのでスナップショット方式を選択
+
+## 4. Live Activity (`ActivityConfiguration`)
+
+`ActivityAttributes` を `Shared/DailyLogActivityAttributes.swift` に定義し、アプリと widget が同じ型を使う。
+
+```swift
+struct DailyLogActivityAttributes: ActivityAttributes {
+    struct ContentState: Codable, Hashable {
+        let startAt: Date
+    }
+    let templateName: String
+    let iconName: String
+    let colorHex: String
+    let isMealType: Bool
+}
+```
+
+- 不変属性 (テンプレ情報) は attributes 側、時刻のみ state 側
+- 経過時間は Live Activity でも `Text(startAt, style: .timer)` で自動更新されるので state を push 更新する必要がない
+
+### 画面
+
+```swift
+ActivityConfiguration(for: DailyLogActivityAttributes.self) { context in
+    LockScreenView(context: context)           // ロック画面
+} dynamicIsland: { context in
+    DynamicIsland {
+        DynamicIslandExpandedRegion(.leading) { ... }
+        DynamicIslandExpandedRegion(.trailing) { ... }
+        DynamicIslandExpandedRegion(.bottom) { ... }
+    } compactLeading: { icon }
+      compactTrailing: { timer }
+      minimal: { icon }
+      .keylineTint(...)
+}
+```
+
+## 5. アプリ側の起動/停止
+
+```swift
+@MainActor
+struct LiveActivityController {
+    func start(template: ActivityTemplate, startAt: Date) {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+        let attributes = DailyLogActivityAttributes(...)
+        let content = ActivityContent(
+            state: DailyLogActivityAttributes.ContentState(startAt: startAt),
+            staleDate: nil
+        )
+        _ = try? ActivityKit.Activity<DailyLogActivityAttributes>.request(
+            attributes: attributes,
+            content: content,
+            pushType: nil
+        )
+    }
+
+    func endAll() async {
+        for activity in ActivityKit.Activity<DailyLogActivityAttributes>.activities {
+            await activity.end(nil, dismissalPolicy: .immediate)
+        }
+    }
+}
+```
+
+- SwiftData の `Activity` と `ActivityKit.Activity` が同名なのでフルパス参照
+- `NSSupportsLiveActivities = YES` が Info.plist に必要 (xcodegen の `INFOPLIST_KEY_NSSupportsLiveActivities: YES` で注入)
+- Push 未使用なので Push Notifications capability は不要
+
+## 注意
+
+- WidgetKit はプロセスがアプリと別。共有は App Group か (ファイル/UserDefaults) か CloudKit 経由のみ
+- シミュレータでも一応動くが、Live Activity は iPhone 14 Pro 相当 (Dynamic Island) のシミュレータで確認した方が早い
+- `containerBackground` を忘れるとウィジェットが真っ白または非表示になる
+- Timeline エントリを大量に突っ込むとバッテリー/cpu budget に跳ね返る。静的スナップショット + `Text(style: .timer)` が推奨


### PR DESCRIPTION
## Summary
全実装の振り返り + 将来の自分 / 新規参加者向けに採用技術のメモを整備。`docs/plan.md` も前マシンから push されていなかったので現状に合わせて再生成。

### 追加ファイル
- `docs/plan.md` — アーキテクチャ概観 (技術表 / 画面ツリー / モデル / サービス / 識別子 / 残件)
- `docs/textbook/swiftdata.md` — `@Model` / `ModelContainer` / `@Query` / CloudKit 互換 / テスト戦略
- `docs/textbook/swiftui.md` — ナビ / @State / expression-too-complex 回避 / UIKit ブリッジ / .fileImporter / timer
- `docs/textbook/swift-charts.md` — Sector/Rectangle/Bar の実コードと軸カスタム
- `docs/textbook/widgetkit.md` — Widget + ActivityKit、App Group snapshot、Dynamic Island の 4 レイアウト
- `docs/textbook/speech-recognition.md` — iOS 17 権限 API / AVAudioEngine ストリーミング / テスト境界
- `docs/textbook/photos-and-files.md` — PhotosPicker / カメラ / App Group / iCloud / ZIP 作成と展開
- `docs/textbook/tooling.md` — xcodegen / SwiftLint / SwiftFormat / GitHub Actions / 実際に踏んだ落とし穴

### 方針
各ファイルは「このアプリでどう使ったか、どこが非自明だったか」に焦点を当てたクックブック形式。教科書的な網羅より実戦メモを優先。

## Verification
- [x] `swiftformat --lint` / `swiftlint --strict` (コード変更なし、docs のみ)
- [x] `make -C ios build` / `make -C ios test` (影響なし、確認のみ)

Closes #4