### PR TITLE
feat: アクション登録画面を親アクション中心にリデザイン (#59)

### DIFF
--- a/ios/DailyLog/Models/ActivityTemplate.swift
+++ b/ios/DailyLog/Models/ActivityTemplate.swift
@@ -10,6 +10,7 @@ final class ActivityTemplate {
     var sortOrder: Int = 0
     var reminderMinutes: Int?
     var isMealType: Bool = false
+    var isHidden: Bool = false
     var createdAt: Date = Date()
 
     var parent: ActivityTemplate?
@@ -28,6 +29,7 @@ final class ActivityTemplate {
         sortOrder: Int = 0,
         reminderMinutes: Int? = nil,
         isMealType: Bool = false,
+        isHidden: Bool = false,
         parent: ActivityTemplate? = nil,
         createdAt: Date = Date()
     ) {
@@ -38,6 +40,7 @@ final class ActivityTemplate {
         self.sortOrder = sortOrder
         self.reminderMinutes = reminderMinutes
         self.isMealType = isMealType
+        self.isHidden = isHidden
         self.parent = parent
         self.createdAt = createdAt
     }

--- a/ios/DailyLog/Views/HomeView.swift
+++ b/ios/DailyLog/Views/HomeView.swift
@@ -11,7 +11,10 @@ struct HomeView: View {
     )
     private var inProgressActivities: [Activity]
 
-    @Query(sort: \ActivityTemplate.sortOrder)
+    @Query(
+        filter: #Predicate<ActivityTemplate> { !$0.isHidden },
+        sort: \ActivityTemplate.sortOrder
+    )
     private var templates: [ActivityTemplate]
 
     @State private var errorMessage: String?
@@ -55,7 +58,7 @@ struct HomeView: View {
                     } label: {
                         Image(systemName: "square.grid.2x2")
                     }
-                    .accessibilityLabel("テンプレート管理")
+                    .accessibilityLabel("アクション管理")
                 }
             }
             .sheet(isPresented: $isPresentingTemplates) {

--- a/ios/DailyLog/Views/Templates/ChildTemplateListView.swift
+++ b/ios/DailyLog/Views/Templates/ChildTemplateListView.swift
@@ -1,0 +1,95 @@
+import SwiftData
+import SwiftUI
+
+struct ChildTemplateListView: View {
+    @Environment(\.modelContext) private var modelContext
+
+    let parent: ActivityTemplate
+
+    @State private var editing: ActivityTemplate?
+    @State private var isPresentingNew = false
+    @State private var errorMessage: String?
+
+    private var service: TemplateService {
+        TemplateService(context: modelContext)
+    }
+
+    private var sortedChildren: [ActivityTemplate] {
+        parent.children.sorted { $0.sortOrder < $1.sortOrder }
+    }
+
+    var body: some View {
+        List {
+            Section("子アクション") {
+                if sortedChildren.isEmpty {
+                    Text("子アクションがありません")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(sortedChildren) { child in
+                        Button {
+                            editing = child
+                        } label: {
+                            TemplateRow(template: child)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .onMove(perform: move)
+                    .onDelete(perform: delete)
+                }
+            }
+        }
+        .navigationTitle(parent.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                EditButton()
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    isPresentingNew = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .accessibilityLabel("子アクションを追加")
+            }
+        }
+        .sheet(item: $editing) { template in
+            TemplateEditView(existing: template)
+        }
+        .sheet(isPresented: $isPresentingNew) {
+            TemplateEditView(existing: nil, defaultParent: parent)
+        }
+        .alert(
+            "エラー",
+            isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            ),
+            presenting: errorMessage
+        ) { _ in
+            Button("OK", role: .cancel) { errorMessage = nil }
+        } message: { message in
+            Text(message)
+        }
+    }
+
+    private func move(from source: IndexSet, to destination: Int) {
+        do {
+            try service.reorder(siblings: sortedChildren, from: source, to: destination)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func delete(at offsets: IndexSet) {
+        let snapshot = sortedChildren
+        for index in offsets {
+            do {
+                try service.delete(snapshot[index])
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+}

--- a/ios/DailyLog/Views/Templates/TemplateEditView.swift
+++ b/ios/DailyLog/Views/Templates/TemplateEditView.swift
@@ -6,6 +6,12 @@ struct TemplateEditView: View {
     @Environment(\.dismiss) private var dismiss
 
     let existing: ActivityTemplate?
+    let defaultParent: ActivityTemplate?
+
+    init(existing: ActivityTemplate?, defaultParent: ActivityTemplate? = nil) {
+        self.existing = existing
+        self.defaultParent = defaultParent
+    }
 
     @Query(sort: \ActivityTemplate.sortOrder)
     private var allTemplates: [ActivityTemplate]
@@ -54,7 +60,7 @@ struct TemplateEditView: View {
                 }
 
                 Section("分類") {
-                    Picker("親テンプレ", selection: $parentID) {
+                    Picker("親アクション", selection: $parentID) {
                         Text("なし").tag(nil as UUID?)
                         ForEach(parentCandidates) { template in
                             Text(template.name).tag(template.id as UUID?)
@@ -71,7 +77,7 @@ struct TemplateEditView: View {
                     }
                 }
             }
-            .navigationTitle(existing == nil ? "新規テンプレ" : "編集")
+            .navigationTitle(existing == nil ? "新規アクション" : "アクション編集")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -82,7 +88,7 @@ struct TemplateEditView: View {
                         .disabled(isSaveDisabled)
                 }
             }
-            .onAppear(perform: loadFromExisting)
+            .onAppear(perform: loadInitialState)
             .alert(
                 "エラー",
                 isPresented: Binding(
@@ -98,20 +104,24 @@ struct TemplateEditView: View {
         }
     }
 
-    private func loadFromExisting() {
-        guard let existing else { return }
-        name = existing.name
-        iconName = existing.iconName
-        colorHex = existing.colorHex
-        parentID = existing.parent?.id
-        if let minutes = existing.reminderMinutes {
-            hasReminder = true
-            reminderMinutes = minutes
-        } else {
-            hasReminder = false
-            reminderMinutes = 30
+    private func loadInitialState() {
+        if let existing {
+            name = existing.name
+            iconName = existing.iconName
+            colorHex = existing.colorHex
+            parentID = existing.parent?.id
+            if let minutes = existing.reminderMinutes {
+                hasReminder = true
+                reminderMinutes = minutes
+            } else {
+                hasReminder = false
+                reminderMinutes = 30
+            }
+            isMealType = existing.isMealType
+        } else if let defaultParent {
+            parentID = defaultParent.id
+            colorHex = defaultParent.colorHex
         }
-        isMealType = existing.isMealType
     }
 
     private func save() {

--- a/ios/DailyLog/Views/Templates/TemplateListView.swift
+++ b/ios/DailyLog/Views/Templates/TemplateListView.swift
@@ -23,17 +23,12 @@ struct TemplateListView: View {
         NavigationStack {
             List {
                 ForEach(rootTemplates) { template in
-                    Button {
-                        editing = template
-                    } label: {
-                        TemplateRow(template: template)
-                    }
-                    .buttonStyle(.plain)
+                    row(for: template)
                 }
                 .onMove(perform: move)
                 .onDelete(perform: delete)
             }
-            .navigationTitle("テンプレート")
+            .navigationTitle("アクション")
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     EditButton()
@@ -44,10 +39,14 @@ struct TemplateListView: View {
                     } label: {
                         Image(systemName: "plus")
                     }
+                    .accessibilityLabel("親アクションを追加")
                 }
                 ToolbarItem(placement: .cancellationAction) {
                     Button("閉じる") { dismiss() }
                 }
+            }
+            .navigationDestination(for: ActivityTemplate.self) { parent in
+                ChildTemplateListView(parent: parent)
             }
             .sheet(item: $editing) { template in
                 TemplateEditView(existing: template)
@@ -68,6 +67,54 @@ struct TemplateListView: View {
                 Text(message)
             }
         }
+    }
+
+    private func row(for template: ActivityTemplate) -> some View {
+        HStack(spacing: 8) {
+            Button {
+                editing = template
+            } label: {
+                TemplateRow(template: template)
+            }
+            .buttonStyle(.plain)
+
+            if !template.children.isEmpty {
+                hiddenToggle(for: template)
+                NavigationLink(value: template) {
+                    Image(systemName: "chevron.right")
+                        .imageScale(.small)
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("\(template.name) の子アクション一覧")
+            }
+        }
+    }
+
+    private func hiddenToggle(for template: ActivityTemplate) -> some View {
+        Toggle(isOn: hiddenBinding(for: template)) {
+            Text("非表示")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .toggleStyle(.switch)
+        .controlSize(.mini)
+        .labelsHidden()
+        .accessibilityLabel("\(template.name) をホームから非表示")
+    }
+
+    private func hiddenBinding(for template: ActivityTemplate) -> Binding<Bool> {
+        Binding(
+            get: { template.isHidden },
+            set: { newValue in
+                template.isHidden = newValue
+                do {
+                    try service.save()
+                } catch {
+                    errorMessage = error.localizedDescription
+                }
+            }
+        )
     }
 
     private func move(from source: IndexSet, to destination: Int) {

--- a/ios/DailyLogTests/ModelTests.swift
+++ b/ios/DailyLogTests/ModelTests.swift
@@ -30,6 +30,17 @@ final class ModelTests: XCTestCase {
     }
 
     @MainActor
+    func testTemplateIsHiddenDefaultsToFalse() throws {
+        let context = container.mainContext
+        let template = ActivityTemplate(name: "勉強")
+        context.insert(template)
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<ActivityTemplate>())
+        XCTAssertEqual(fetched.first?.isHidden, false)
+    }
+
+    @MainActor
     func testTemplateHierarchy() throws {
         let context = container.mainContext
         let parent = ActivityTemplate(name: "仕事")


### PR DESCRIPTION
## Summary
- `ActivityTemplate.isHidden`(Bool, default false) を追加
- TemplateListView: 親アクションのみ表示し、子持ち親には行内に「非表示」トグル+`>`(子アクション一覧へ遷移) を配置
- ChildTemplateListView を新規追加(子の一覧/編集/追加/並べ替え/削除)
- TemplateEditView: 用語を「アクション」に統一、`defaultParent` 受け取りで子追加時に親を事前選択 + 親の色を引き継ぎ
- HomeView: `isHidden=true` を除外し、ボタンの accessibilityLabel をアクション管理に統一

## 仕様根拠 (#59)
- 表示するのは親アクションのみ
- 親アクション自体もアクションとして記録可能(タップで開始)
- 子アクションを持つものは `>` で子一覧画面に遷移
- 子アクション持ちには非表示トグル → ON で親をホームから外す
- 非表示トグルはアクション一覧のインライン配置 (確定済み)

## Test plan
- [x] `make build` 成功
- [x] `make test` 75 件全パス (isHidden default test 追加)
- [x] `make lint` violations 0
- [x] `make format-check` OK
- [ ] 実機/シミュレータ動作確認:
  - [ ] 親アクション追加(`+`) → 親のみのリストに出る
  - [ ] 子持ち親に `>` と非表示トグルが表示される
  - [ ] `>` で子アクション一覧に遷移し、子の追加/編集ができる
  - [ ] 非表示 ON にすると Home から親が消える(子は残る)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)