### PR TITLE
feat: ロック画面 Live Activity に停止と次候補ボタンを追加 (#51)

### DIFF
--- a/ios/DailyLog/Services/ActivityService.swift
+++ b/ios/DailyLog/Services/ActivityService.swift
@@ -27,6 +27,7 @@ struct ActivityService {
         for activity in closed {
             notifier.cancelReminder(for: activity)
         }
+        let candidates = (try? predictNextCandidates(excluding: template.id, at: now)) ?? []
         let activity = Activity(template: template, startAt: now)
         context.insert(activity)
         try context.save()
@@ -35,8 +36,34 @@ struct ActivityService {
         }
         publishSnapshot(for: activity)
         Task { await LiveActivityController.shared.endAll() }
-        LiveActivityController.shared.start(template: template, startAt: now)
+        LiveActivityController.shared.start(
+            template: template,
+            startAt: now,
+            nextCandidates: candidates
+        )
         return activity
+    }
+
+    private func predictNextCandidates(
+        excluding excludedID: UUID,
+        at now: Date,
+        limit: Int = NextActionPredictor.defaultLimit
+    ) throws -> [NextActionCandidate] {
+        let predictor = NextActionPredictor()
+        let templates = try predictor.predict(
+            at: now,
+            in: context,
+            excluding: excludedID,
+            limit: limit
+        )
+        return templates.map { template in
+            NextActionCandidate(
+                templateID: template.id,
+                name: template.name,
+                iconName: template.iconName,
+                colorHex: template.colorHex
+            )
+        }
     }
 
     /// 最も古い進行中を 1 件停止して返す。複数ある場合は防御的に全て停止する。

--- a/ios/DailyLog/Services/LiveActivityController.swift
+++ b/ios/DailyLog/Services/LiveActivityController.swift
@@ -9,7 +9,7 @@ import Foundation
 struct LiveActivityController {
     static let shared = LiveActivityController()
 
-    func start(template: ActivityTemplate, startAt: Date) {
+    func start(template: ActivityTemplate, startAt: Date, nextCandidates: [NextActionCandidate] = []) {
         guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
 
         let attributes = DailyLogActivityAttributes(
@@ -18,7 +18,10 @@ struct LiveActivityController {
             colorHex: template.colorHex,
             isMealType: template.isMealType
         )
-        let state = DailyLogActivityAttributes.ContentState(startAt: startAt)
+        let state = DailyLogActivityAttributes.ContentState(
+            startAt: startAt,
+            nextCandidates: nextCandidates
+        )
         let content = ActivityContent(state: state, staleDate: nil)
 
         do {

--- a/ios/DailyLog/Services/NextActionPredictor.swift
+++ b/ios/DailyLog/Services/NextActionPredictor.swift
@@ -1,0 +1,127 @@
+import Foundation
+import SwiftData
+
+/// 過去ログから「曜日 × 時間帯」に基づき次に来そうなアクションを予測する。
+///
+/// アルゴリズム:
+/// 1. `now` の (曜日, 時間バケット) と一致する過去 Activity をテンプレ別にカウント
+/// 2. カウント降順に並べる
+/// 3. 同バケットで N 件に満たない場合は全期間頻度で穴埋め
+/// 4. それでも不足するときは sortOrder 順で穴埋め
+/// 5. 開始直後の自テンプレ + 非表示テンプレは除外
+struct NextActionPredictor {
+    static let defaultHourBucketSize = 1
+    static let defaultLimit = 3
+
+    let calendar: Calendar
+    let hourBucketSize: Int
+
+    init(calendar: Calendar = .current, hourBucketSize: Int = NextActionPredictor.defaultHourBucketSize) {
+        self.calendar = calendar
+        self.hourBucketSize = max(1, hourBucketSize)
+    }
+
+    @MainActor
+    func predict(
+        at now: Date,
+        in context: ModelContext,
+        excluding excludedTemplateID: UUID? = nil,
+        limit: Int = NextActionPredictor.defaultLimit
+    ) throws -> [ActivityTemplate] {
+        let templates = try context.fetch(FetchDescriptor<ActivityTemplate>())
+        let visibleTemplates = templates.filter { !$0.isHidden }
+        guard !visibleTemplates.isEmpty else { return [] }
+
+        let activities = try context.fetch(FetchDescriptor<Activity>())
+        let targetBucket = bucket(for: now)
+        let templateByID = Dictionary(uniqueKeysWithValues: visibleTemplates.map { ($0.id, $0) })
+
+        let bucketCounts = countsByTemplate(in: activities) { activity in
+            bucket(for: activity.startAt) == targetBucket
+        }
+        let overallCounts = countsByTemplate(in: activities) { _ in true }
+
+        var picker = CandidatePicker(
+            limit: limit,
+            excluded: excludedTemplateID,
+            templateByID: templateByID
+        )
+        picker.add(ranked: rank(counts: bucketCounts, templateByID: templateByID))
+        picker.add(ranked: rank(counts: overallCounts, templateByID: templateByID))
+        picker.padWithSortOrder(visibleTemplates.sorted { $0.sortOrder < $1.sortOrder })
+        return picker.picked
+    }
+
+    private func countsByTemplate(
+        in activities: [Activity],
+        where predicate: (Activity) -> Bool
+    ) -> [UUID: Int] {
+        var counts: [UUID: Int] = [:]
+        for activity in activities {
+            guard let templateID = activity.template?.id else { continue }
+            guard predicate(activity) else { continue }
+            counts[templateID, default: 0] += 1
+        }
+        return counts
+    }
+
+    @MainActor
+    private func rank(
+        counts: [UUID: Int],
+        templateByID: [UUID: ActivityTemplate]
+    ) -> [UUID] {
+        counts.sorted { lhs, rhs in
+            if lhs.value != rhs.value { return lhs.value > rhs.value }
+            return (templateByID[lhs.key]?.sortOrder ?? .max) < (templateByID[rhs.key]?.sortOrder ?? .max)
+        }
+        .map(\.key)
+    }
+
+    func bucket(for date: Date) -> Bucket {
+        let components = calendar.dateComponents([.weekday, .hour], from: date)
+        let weekday = components.weekday ?? 1
+        let hour = components.hour ?? 0
+        return Bucket(weekday: weekday, hourBucket: hour / hourBucketSize)
+    }
+
+    struct Bucket: Hashable {
+        let weekday: Int
+        let hourBucket: Int
+    }
+
+    @MainActor
+    fileprivate struct CandidatePicker {
+        let limit: Int
+        let excluded: UUID?
+        let templateByID: [UUID: ActivityTemplate]
+        private(set) var picked: [ActivityTemplate] = []
+        private var pickedIDs = Set<UUID>()
+
+        init(limit: Int, excluded: UUID?, templateByID: [UUID: ActivityTemplate]) {
+            self.limit = limit
+            self.excluded = excluded
+            self.templateByID = templateByID
+        }
+
+        mutating func add(ranked ids: [UUID]) {
+            for id in ids where picked.count < limit {
+                addIfEligible(id: id)
+            }
+        }
+
+        mutating func padWithSortOrder(_ visibleTemplates: [ActivityTemplate]) {
+            for template in visibleTemplates where picked.count < limit {
+                addIfEligible(id: template.id)
+            }
+        }
+
+        private mutating func addIfEligible(id: UUID) {
+            guard picked.count < limit else { return }
+            guard id != excluded else { return }
+            guard !pickedIDs.contains(id) else { return }
+            guard let template = templateByID[id] else { return }
+            picked.append(template)
+            pickedIDs.insert(id)
+        }
+    }
+}

--- a/ios/DailyLogTests/NextActionPredictorTests.swift
+++ b/ios/DailyLogTests/NextActionPredictorTests.swift
@@ -1,0 +1,151 @@
+@testable import DailyLog
+import SwiftData
+import XCTest
+
+@MainActor
+final class NextActionPredictorTests: XCTestCase {
+    private var container: ModelContainer!
+    private var context: ModelContext {
+        container.mainContext
+    }
+
+    private var calendar: Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        if let tz = TimeZone(identifier: "Asia/Tokyo") {
+            cal.timeZone = tz
+        }
+        return cal
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        container = try AppModelContainer.makeContainer(inMemory: true)
+    }
+
+    override func tearDownWithError() throws {
+        container = nil
+        try super.tearDownWithError()
+    }
+
+    func testPredictsByDayOfWeekAndHourBucket() throws {
+        let cal = calendar
+        let work = ActivityTemplate(name: "仕事", sortOrder: 0)
+        let study = ActivityTemplate(name: "勉強", sortOrder: 1)
+        let exercise = ActivityTemplate(name: "運動", sortOrder: 2)
+        context.insert(work)
+        context.insert(study)
+        context.insert(exercise)
+
+        // 月曜 21時台のログ: 勉強 x3, 仕事 x1
+        let mondayBase = makeDate(year: 2026, month: 5, day: 11, hour: 21, calendar: cal)
+        insertActivity(template: study, startAt: mondayBase)
+        insertActivity(template: study, startAt: mondayBase.addingTimeInterval(60 * 60 * 24 * 7))
+        insertActivity(template: study, startAt: mondayBase.addingTimeInterval(60 * 60 * 24 * 14))
+        insertActivity(template: work, startAt: mondayBase.addingTimeInterval(60 * 60 * 24 * 21))
+
+        // 月曜 9時台のログ (別バケット): 仕事 x5
+        let mondayMorning = makeDate(year: 2026, month: 5, day: 11, hour: 9, calendar: cal)
+        for offsetWeek in 0 ..< 5 {
+            insertActivity(
+                template: work,
+                startAt: mondayMorning.addingTimeInterval(60 * 60 * 24 * 7 * Double(offsetWeek))
+            )
+        }
+
+        try context.save()
+
+        let predictor = NextActionPredictor(calendar: cal)
+        let target = makeDate(year: 2026, month: 5, day: 18, hour: 21, calendar: cal)
+        let result = try predictor.predict(at: target, in: context, excluding: nil, limit: 2)
+
+        XCTAssertEqual(result.first?.name, "勉強", "月曜21時台で頻度最高は勉強")
+        XCTAssertEqual(result.count, 2)
+    }
+
+    func testExcludesCurrentTemplate() throws {
+        let cal = calendar
+        let work = ActivityTemplate(name: "仕事", sortOrder: 0)
+        let study = ActivityTemplate(name: "勉強", sortOrder: 1)
+        context.insert(work)
+        context.insert(study)
+
+        let monday = makeDate(year: 2026, month: 5, day: 11, hour: 21, calendar: cal)
+        insertActivity(template: study, startAt: monday)
+        insertActivity(template: study, startAt: monday.addingTimeInterval(60 * 60 * 24 * 7))
+        try context.save()
+
+        let predictor = NextActionPredictor(calendar: cal)
+        let target = makeDate(year: 2026, month: 5, day: 18, hour: 21, calendar: cal)
+        let result = try predictor.predict(at: target, in: context, excluding: study.id, limit: 3)
+
+        XCTAssertFalse(result.contains(where: { $0.id == study.id }), "現在テンプレは候補から除外")
+        XCTAssertTrue(result.contains(where: { $0.id == work.id }), "他テンプレで穴埋め")
+    }
+
+    func testExcludesHiddenTemplates() throws {
+        let cal = calendar
+        let work = ActivityTemplate(name: "仕事", sortOrder: 0)
+        let hiddenParent = ActivityTemplate(name: "運動", sortOrder: 1, isHidden: true)
+        context.insert(work)
+        context.insert(hiddenParent)
+
+        let monday = makeDate(year: 2026, month: 5, day: 11, hour: 21, calendar: cal)
+        insertActivity(template: hiddenParent, startAt: monday)
+        try context.save()
+
+        let predictor = NextActionPredictor(calendar: cal)
+        let target = makeDate(year: 2026, month: 5, day: 18, hour: 21, calendar: cal)
+        let result = try predictor.predict(at: target, in: context, excluding: nil, limit: 3)
+
+        XCTAssertFalse(result.contains(where: { $0.id == hiddenParent.id }), "非表示テンプレは候補に出ない")
+    }
+
+    func testFallsBackToOverallFrequencyWhenBucketEmpty() throws {
+        let cal = calendar
+        let work = ActivityTemplate(name: "仕事", sortOrder: 0)
+        let study = ActivityTemplate(name: "勉強", sortOrder: 1)
+        context.insert(work)
+        context.insert(study)
+
+        // 全期間で勉強の方が多いが、月曜21時台のログはゼロ
+        let randomDate = makeDate(year: 2026, month: 5, day: 12, hour: 14, calendar: cal)
+        for offsetDay in 0 ..< 4 {
+            insertActivity(template: study, startAt: randomDate.addingTimeInterval(60 * 60 * 24 * Double(offsetDay)))
+        }
+        insertActivity(template: work, startAt: randomDate)
+        try context.save()
+
+        let predictor = NextActionPredictor(calendar: cal)
+        let target = makeDate(year: 2026, month: 5, day: 18, hour: 21, calendar: cal)
+        let result = try predictor.predict(at: target, in: context, excluding: nil, limit: 1)
+
+        XCTAssertEqual(result.first?.name, "勉強", "バケットが空なら全期間頻度で穴埋め")
+    }
+
+    func testReturnsEmptyWhenNoVisibleTemplates() throws {
+        let cal = calendar
+        let predictor = NextActionPredictor(calendar: cal)
+        let target = makeDate(year: 2026, month: 5, day: 18, hour: 21, calendar: cal)
+        let result = try predictor.predict(at: target, in: context, excluding: nil, limit: 3)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    private func insertActivity(template: ActivityTemplate, startAt: Date) {
+        let activity = Activity(template: template, startAt: startAt, endAt: startAt.addingTimeInterval(600))
+        context.insert(activity)
+    }
+
+    private func makeDate(year: Int, month: Int, day: Int, hour: Int, calendar: Calendar) -> Date {
+        var components = DateComponents()
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = 0
+        guard let date = calendar.date(from: components) else {
+            XCTFail("Failed to build date for \(year)-\(month)-\(day) \(hour):00")
+            return Date()
+        }
+        return date
+    }
+}

--- a/ios/DailyLogWidget/DailyLogLiveActivity.swift
+++ b/ios/DailyLogWidget/DailyLogLiveActivity.swift
@@ -1,4 +1,5 @@
 import ActivityKit
+import AppIntents
 import SwiftUI
 import WidgetKit
 
@@ -21,9 +22,27 @@ struct DailyLogLiveActivity: Widget {
                         .font(.title3)
                         .frame(maxWidth: 72, alignment: .trailing)
                 }
-                DynamicIslandExpandedRegion(.bottom) {
+                DynamicIslandExpandedRegion(.center) {
                     Text(context.attributes.templateName)
                         .font(.headline)
+                        .lineLimit(1)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    HStack(spacing: 8) {
+                        Button(intent: StopCurrentActivityIntent()) {
+                            Label("停止", systemImage: "stop.fill")
+                                .font(.subheadline)
+                        }
+                        .tint(.red)
+                        ForEach(context.state.nextCandidates.prefix(2)) { candidate in
+                            Button(intent: StartTemplateIntent(templateID: candidate.templateID)) {
+                                Label(candidate.name, systemImage: candidate.iconName)
+                                    .font(.subheadline)
+                                    .lineLimit(1)
+                            }
+                            .tint(Color(hex: candidate.colorHex) ?? .accentColor)
+                        }
+                    }
                 }
             } compactLeading: {
                 icon(for: context.attributes)
@@ -54,24 +73,36 @@ private struct LockScreenView: View {
     let context: ActivityViewContext<DailyLogActivityAttributes>
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 10) {
                 iconBadge
-                Text(context.attributes.templateName)
-                    .font(.headline)
-                Spacer()
-                if context.attributes.isMealType {
-                    Label("食事", systemImage: "fork.knife")
-                        .labelStyle(.iconOnly)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(context.attributes.templateName)
+                        .font(.headline)
+                        .lineLimit(1)
+                    Text(context.state.startAt, style: .timer)
+                        .font(.system(.title3, design: .monospaced))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.6)
                 }
+
+                Spacer()
+
+                Button(intent: StopCurrentActivityIntent()) {
+                    Label("停止", systemImage: "stop.fill")
+                        .labelStyle(.iconOnly)
+                        .font(.title3)
+                        .padding(10)
+                }
+                .tint(.red)
+                .buttonStyle(.bordered)
+                .accessibilityLabel("停止")
             }
 
-            Text(context.state.startAt, style: .timer)
-                .font(.system(.largeTitle, design: .monospaced))
-                .lineLimit(1)
-                .minimumScaleFactor(0.6)
+            if !context.state.nextCandidates.isEmpty {
+                candidateRow
+            }
         }
         .padding()
     }
@@ -85,5 +116,24 @@ private struct LockScreenView: View {
                 Circle()
                     .fill(Color(hex: context.attributes.colorHex) ?? .accentColor)
             )
+    }
+
+    private var candidateRow: some View {
+        HStack(spacing: 6) {
+            Text("次:")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            ForEach(context.state.nextCandidates.prefix(3)) { candidate in
+                Button(intent: StartTemplateIntent(templateID: candidate.templateID)) {
+                    Label(candidate.name, systemImage: candidate.iconName)
+                        .font(.caption)
+                        .lineLimit(1)
+                        .padding(.horizontal, 4)
+                }
+                .tint(Color(hex: candidate.colorHex) ?? .accentColor)
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+        }
     }
 }

--- a/ios/Shared/DailyLogActivityAttributes.swift
+++ b/ios/Shared/DailyLogActivityAttributes.swift
@@ -3,11 +3,17 @@ import Foundation
 
 /// ロック画面 / Dynamic Island 表示に使う ActivityKit の attributes。
 ///
-/// 不変属性 (テンプレ情報) は `ActivityAttributes` 側、時刻のみ動的な
-/// `ContentState` 側にまとめる。
+/// 不変属性 (現在のテンプレ情報) は `ActivityAttributes` 側、可変な
+/// `ContentState` 側には次候補リストを持たせる。
 struct DailyLogActivityAttributes: ActivityAttributes {
     struct ContentState: Codable, Hashable {
         let startAt: Date
+        let nextCandidates: [NextActionCandidate]
+
+        init(startAt: Date, nextCandidates: [NextActionCandidate] = []) {
+            self.startAt = startAt
+            self.nextCandidates = nextCandidates
+        }
     }
 
     let templateName: String

--- a/ios/Shared/LiveActivityIntents.swift
+++ b/ios/Shared/LiveActivityIntents.swift
@@ -1,0 +1,63 @@
+import AppIntents
+import Foundation
+#if HOST_APP
+    import SwiftData
+#endif
+
+/// ロック画面 / Dynamic Island の停止ボタンから呼ばれる。
+///
+/// `LiveActivityIntent` は host app プロセスで実行されるため、本体アプリと
+/// 同じ SwiftData ストア / `ActivityService` を経由してデータ整合性を保てる。
+/// Shared/ に置いてあるが perform 本体は host 限定 (`#if HOST_APP`)。
+struct StopCurrentActivityIntent: LiveActivityIntent {
+    static var title: LocalizedStringResource = "現在のアクションを停止"
+    static var description = IntentDescription("進行中のアクションをロック画面から停止します。")
+
+    func perform() async throws -> some IntentResult {
+        #if HOST_APP
+            try await MainActor.run {
+                let container = try AppModelContainer.makeContainer()
+                let context = ModelContext(container)
+                let service = ActivityService(context: context)
+                try service.stopCurrent()
+            }
+        #endif
+        return .result()
+    }
+}
+
+/// 候補アクションをタップしたときに呼ばれる。指定 ID のテンプレで開始する。
+struct StartTemplateIntent: LiveActivityIntent {
+    static var title: LocalizedStringResource = "アクションを開始"
+    static var description = IntentDescription("指定されたアクションを開始します。")
+
+    @Parameter(title: "Template ID")
+    var templateIDString: String
+
+    init() {
+        templateIDString = ""
+    }
+
+    init(templateID: UUID) {
+        templateIDString = templateID.uuidString
+    }
+
+    func perform() async throws -> some IntentResult {
+        #if HOST_APP
+            guard let templateID = UUID(uuidString: templateIDString) else {
+                return .result()
+            }
+            try await MainActor.run {
+                let container = try AppModelContainer.makeContainer()
+                let context = ModelContext(container)
+                let descriptor = FetchDescriptor<ActivityTemplate>(
+                    predicate: #Predicate { $0.id == templateID }
+                )
+                guard let template = try context.fetch(descriptor).first else { return }
+                let service = ActivityService(context: context)
+                try service.start(template: template)
+            }
+        #endif
+        return .result()
+    }
+}

--- a/ios/Shared/NextActionCandidate.swift
+++ b/ios/Shared/NextActionCandidate.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Live Activity / ロック画面に表示する「次の候補アクション」の最小情報。
+///
+/// テンプレ ID を持つことで、ロック画面ボタンから直接そのアクションを開始できる
+/// (StartTemplateIntent 経由)。
+struct NextActionCandidate: Codable, Hashable, Identifiable {
+    var id: UUID {
+        templateID
+    }
+
+    let templateID: UUID
+    let name: String
+    let iconName: String
+    let colorHex: String
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -37,6 +37,9 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.coco.daily-log
         PRODUCT_NAME: DailyLog
+        # Live Activity Intent の perform() は host app プロセスのみで動く。
+        # Shared/ 配下に置く必要があるため、host 限定コードを #if HOST_APP で囲む。
+        SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) HOST_APP"
         CODE_SIGN_ENTITLEMENTS: DailyLog/DailyLog.entitlements
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_KEY_CFBundleDisplayName: DailyLog


### PR DESCRIPTION
## Summary
- ロック画面 / Dynamic Island 拡張ビューに **停止ボタン** と **次候補アクション 2-3件** を表示
- `StopCurrentActivityIntent` / `StartTemplateIntent` (LiveActivityIntent) で host app プロセスから SwiftData を更新
- `NextActionPredictor` で「曜日 × 時間バケット」の頻度から次候補を予測
- 同バケットで足りなければ全期間頻度→sortOrder の順に穴埋め
- 自テンプレ・`isHidden=true` は候補から除外

## 仕様根拠 (#51)
- 次候補ロジック: **時間帯ベース** (確定済み)
- 停止ボタン: **タップで即停止** (確定済み)

## 設計メモ
- `Shared/LiveActivityIntents.swift` の perform 本体は app 専用シンボルを参照するため、`HOST_APP` コンパイル条件で囲み widget extension からは空実装としてコンパイル
- `LiveActivityController.start` は `nextCandidates` を受け取り `ContentState` に乗せる
- ActivityService.start は予測結果を作って LiveActivityController に渡す

## Test plan
- [x] `make build` 成功
- [x] `make test` 80 件 (NextActionPredictor 5 件追加) 全パス
- [x] `make lint --strict` violations 0
- [x] `make format-check` OK
- [ ] 実機/シミュレータ確認:
  - [ ] アクション開始 → ロック画面に Live Activity 出現
  - [ ] 停止ボタンタップ → アクション停止 + Live Activity 終了
  - [ ] 候補ボタンタップ → そのテンプレで新規アクション開始
  - [ ] 候補は時間帯 (現曜日 × 現在時) に多いタスクが上位

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)