### PR TITLE
feat: アラートデフォルト分数を全面更新 (#56)

### DIFF
--- a/ios/DailyLog/Models/AppModelContainer.swift
+++ b/ios/DailyLog/Models/AppModelContainer.swift
@@ -23,8 +23,26 @@ enum AppModelContainer {
         let container = try ModelContainer(for: schema, configurations: configuration)
         if !inMemory {
             try seedIfNeeded(container: container)
+            try applyAlertDefaultsV2IfNeeded(container: container)
         }
         return container
+    }
+
+    /// 既存テンプレのアラート分数を新デフォルト (#56) に再適用する。一度だけ走る。
+    /// 「既存も全部上書き」のため、ユーザー手動変更も含めて新デフォルトで置換する。
+    static func applyAlertDefaultsV2IfNeeded(container: ModelContainer) throws {
+        guard !AppPreferences.alertDefaultsV2Applied else { return }
+        let context = ModelContext(container)
+        let templates = try context.fetch(FetchDescriptor<ActivityTemplate>())
+        for template in templates {
+            if let minutes = DefaultTemplates.reminderDefaultsByName[template.name] {
+                template.reminderMinutes = minutes
+            }
+        }
+        if context.hasChanges {
+            try context.save()
+        }
+        AppPreferences.alertDefaultsV2Applied = true
     }
 
     static func reseedDefaultTemplates(in context: ModelContext) throws {

--- a/ios/DailyLog/Models/DefaultTemplates.swift
+++ b/ios/DailyLog/Models/DefaultTemplates.swift
@@ -10,12 +10,12 @@ enum DefaultTemplates {
     }
 
     static let presets: [Preset] = [
-        Preset(name: "睡眠", iconName: "moon.fill", colorHex: "#6F5BE8", reminderMinutes: nil, isMealType: false),
-        Preset(name: "食事", iconName: "fork.knife", colorHex: "#F5A623", reminderMinutes: nil, isMealType: true),
-        Preset(name: "仕事", iconName: "briefcase.fill", colorHex: "#4A90E2", reminderMinutes: 60, isMealType: false),
-        Preset(name: "勉強", iconName: "book.fill", colorHex: "#50C9BA", reminderMinutes: 45, isMealType: false),
-        Preset(name: "運動", iconName: "figure.run", colorHex: "#E95E77", reminderMinutes: nil, isMealType: false),
-        Preset(name: "移動", iconName: "tram.fill", colorHex: "#7F8C8D", reminderMinutes: nil, isMealType: false),
+        Preset(name: "睡眠", iconName: "moon.fill", colorHex: "#6F5BE8", reminderMinutes: 600, isMealType: false),
+        Preset(name: "食事", iconName: "fork.knife", colorHex: "#F5A623", reminderMinutes: 120, isMealType: true),
+        Preset(name: "仕事", iconName: "briefcase.fill", colorHex: "#4A90E2", reminderMinutes: 600, isMealType: false),
+        Preset(name: "勉強", iconName: "book.fill", colorHex: "#50C9BA", reminderMinutes: 480, isMealType: false),
+        Preset(name: "運動", iconName: "figure.run", colorHex: "#E95E77", reminderMinutes: 120, isMealType: false),
+        Preset(name: "移動", iconName: "tram.fill", colorHex: "#7F8C8D", reminderMinutes: 120, isMealType: false),
         Preset(
             name: "休憩",
             iconName: "cup.and.saucer.fill",
@@ -31,4 +31,12 @@ enum DefaultTemplates {
             isMealType: false
         ),
     ]
+
+    /// 名前で一致する既存テンプレに、新デフォルトのアラート分数を再適用する。
+    /// `nil` の preset (休憩/趣味) は対象外。
+    static let reminderDefaultsByName: [String: Int] = Dictionary(
+        uniqueKeysWithValues: presets.compactMap { preset in
+            preset.reminderMinutes.map { (preset.name, $0) }
+        }
+    )
 }

--- a/ios/DailyLog/Services/AppPreferences.swift
+++ b/ios/DailyLog/Services/AppPreferences.swift
@@ -8,6 +8,7 @@ enum AppPreferences {
     enum Keys {
         static let iCloudSyncEnabled = "pref.iCloudSyncEnabled"
         static let notificationsEnabled = "pref.notificationsEnabled"
+        static let alertDefaultsV2Applied = "pref.alertDefaultsV2Applied"
     }
 
     private static var store: UserDefaults {
@@ -27,5 +28,10 @@ enum AppPreferences {
             return true
         }
         set { store.set(newValue, forKey: Keys.notificationsEnabled) }
+    }
+
+    static var alertDefaultsV2Applied: Bool {
+        get { store.bool(forKey: Keys.alertDefaultsV2Applied) }
+        set { store.set(newValue, forKey: Keys.alertDefaultsV2Applied) }
     }
 }

--- a/ios/DailyLogTests/ModelTests.swift
+++ b/ios/DailyLogTests/ModelTests.swift
@@ -126,6 +126,19 @@ final class ModelTests: XCTestCase {
     }
 
     @MainActor
+    func testReminderDefaultsByNameMatchesPresets() {
+        XCTAssertEqual(DefaultTemplates.reminderDefaultsByName["睡眠"], 600)
+        XCTAssertEqual(DefaultTemplates.reminderDefaultsByName["食事"], 120)
+        XCTAssertEqual(DefaultTemplates.reminderDefaultsByName["仕事"], 600)
+        XCTAssertEqual(DefaultTemplates.reminderDefaultsByName["勉強"], 480)
+        XCTAssertEqual(DefaultTemplates.reminderDefaultsByName["運動"], 120)
+        XCTAssertEqual(DefaultTemplates.reminderDefaultsByName["移動"], 120)
+        // 休憩・趣味は nil なので辞書に含まれない
+        XCTAssertNil(DefaultTemplates.reminderDefaultsByName["休憩"])
+        XCTAssertNil(DefaultTemplates.reminderDefaultsByName["趣味"])
+    }
+
+    @MainActor
     func testDefaultTemplateSeeding() throws {
         let seededContainer = try AppModelContainer.makeContainer(inMemory: false)
         let context = ModelContext(seededContainer)


### PR DESCRIPTION
## Summary
- DefaultTemplates の reminderMinutes を新しい値に: 睡眠 600 / 食事 120 / 仕事 600 / 勉強 480 / 運動 120 / 移動 120
- 既存ユーザーのテンプレも名前一致で one-shot マイグレーション (`applyAlertDefaultsV2IfNeeded`) で新デフォルトに上書き
- 再実行防止フラグ `AppPreferences.alertDefaultsV2Applied`

## 仕様根拠 (#56)
- 適用範囲: **既存も全部上書き** (確定済み)

## Test plan
- [x] `make test` 81 件パス (新規 1 件追加)
- [x] `make lint --strict` 0 violations
- [x] `make format-check` OK