### PR TITLE
feat: 統計の色を親テンプレ基準で統一・凡例追加 (#53)

### DIFF
--- a/ios/DailyLog/Utilities/DayActivitySummary.swift
+++ b/ios/DailyLog/Utilities/DayActivitySummary.swift
@@ -39,7 +39,7 @@ enum DayActivitySummary {
 
             let key: UUID? = activity.template?.id
             let name = activity.template?.name ?? "（未分類）"
-            let color = activity.template?.colorHex ?? "#7F8C8D"
+            let color = displayColor(for: activity.template)
             if var existing = buckets[key] {
                 existing.seconds += seconds
                 buckets[key] = existing
@@ -58,5 +58,14 @@ enum DayActivitySummary {
                 )
             }
             .sorted { $0.totalSeconds > $1.totalSeconds }
+    }
+
+    /// 表示色を決定する。親テンプレを持つ場合は親色を sortOrder で濃淡シフトした色を返す。
+    private static func displayColor(for template: ActivityTemplate?) -> String {
+        guard let template else { return "#7F8C8D" }
+        guard let parent = template.parent else { return template.colorHex }
+        let siblings = parent.children.sorted { $0.sortOrder < $1.sortOrder }
+        let index = siblings.firstIndex(where: { $0.id == template.id }) ?? 0
+        return HexColor.shaded(parentHex: parent.colorHex, childIndex: index)
     }
 }

--- a/ios/DailyLog/Utilities/PeriodActivitySummary.swift
+++ b/ios/DailyLog/Utilities/PeriodActivitySummary.swift
@@ -139,12 +139,13 @@ enum PeriodActivitySummary {
             }
         }
         return rootIDs
-            .map { buildNode(id: $0, buckets: buckets, childrenByParent: childrenByParent) }
+            .map { buildNode(id: $0, parentHex: nil, buckets: buckets, childrenByParent: childrenByParent) }
             .sorted { $0.totalSeconds > $1.totalSeconds }
     }
 
     private static func buildNode(
         id: UUID,
+        parentHex: String?,
         buckets: [UUID: Bucket],
         childrenByParent: [UUID: [UUID]]
     ) -> CategoryStats {
@@ -157,17 +158,34 @@ enum PeriodActivitySummary {
                 children: []
             )
         }
+        let nodeHex: String = if let parentHex {
+            // 子は親色の濃淡で区別する。 sortOrder 順で連続的にシフト。
+            HexColor.shaded(parentHex: parentHex, childIndex: childShadeIndex(of: bucket.template))
+        } else {
+            bucket.template.colorHex
+        }
         let childIDs = childrenByParent[id] ?? []
         let children = childIDs
-            .map { buildNode(id: $0, buckets: buckets, childrenByParent: childrenByParent) }
+            .map { buildNode(
+                id: $0,
+                parentHex: bucket.template.colorHex,
+                buckets: buckets,
+                childrenByParent: childrenByParent
+            ) }
             .sorted { $0.totalSeconds > $1.totalSeconds }
         let childSum = children.reduce(0) { $0 + $1.totalSeconds }
         return CategoryStats(
             id: id,
             templateName: bucket.template.name,
-            colorHex: bucket.template.colorHex,
+            colorHex: nodeHex,
             totalSeconds: bucket.seconds + childSum,
             children: children
         )
+    }
+
+    private static func childShadeIndex(of template: ActivityTemplate) -> Int {
+        guard let siblings = template.parent?.children else { return 0 }
+        let ordered = siblings.sorted { $0.sortOrder < $1.sortOrder }
+        return ordered.firstIndex(where: { $0.id == template.id }) ?? 0
     }
 }

--- a/ios/DailyLog/Views/Stats/CategoryBarChart.swift
+++ b/ios/DailyLog/Views/Stats/CategoryBarChart.swift
@@ -5,6 +5,13 @@ struct CategoryBarChart: View {
     let categories: [PeriodActivitySummary.CategoryStats]
 
     var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            chart
+            legend
+        }
+    }
+
+    private var chart: some View {
         Chart {
             ForEach(categories) { category in
                 BarMark(
@@ -31,6 +38,24 @@ struct CategoryBarChart: View {
         }
         .chartYAxis {
             AxisMarks(position: .leading)
+        }
+    }
+
+    private var legend: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(categories) { category in
+                HStack(spacing: 8) {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(Color(hex: category.colorHex) ?? .accentColor)
+                        .frame(width: 10, height: 10)
+                    Text(category.templateName)
+                        .font(.caption)
+                    Spacer()
+                    Text(DurationFormatter.elapsed(seconds: Int(category.totalSeconds)))
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            }
         }
     }
 }

--- a/ios/DailyLogTests/HexColorTests.swift
+++ b/ios/DailyLogTests/HexColorTests.swift
@@ -1,0 +1,50 @@
+@testable import DailyLog
+import XCTest
+
+final class HexColorTests: XCTestCase {
+    func testParseSixDigitHex() throws {
+        let rgb = try XCTUnwrap(HexColor.parse(hex: "#FF8040"))
+        XCTAssertEqual(rgb.red, 1.0, accuracy: 0.001)
+        XCTAssertEqual(rgb.green, 128.0 / 255.0, accuracy: 0.001)
+        XCTAssertEqual(rgb.blue, 64.0 / 255.0, accuracy: 0.001)
+    }
+
+    func testParseRejectsInvalid() {
+        XCTAssertNil(HexColor.parse(hex: "123"))
+        XCTAssertNil(HexColor.parse(hex: "#ZZZZZZ"))
+        XCTAssertNil(HexColor.parse(hex: ""))
+    }
+
+    func testMixedPositiveLightens() {
+        let result = HexColor.mixed(hex: "#000000", amount: 0.5)
+        XCTAssertEqual(result, "#808080", "0.5 toward white from black ≈ mid grey")
+    }
+
+    func testMixedNegativeDarkens() {
+        let result = HexColor.mixed(hex: "#FFFFFF", amount: -0.5)
+        XCTAssertEqual(result, "#808080", "0.5 toward black from white ≈ mid grey")
+    }
+
+    func testMixedClampsOutOfRange() {
+        XCTAssertEqual(HexColor.mixed(hex: "#000000", amount: 5.0), "#FFFFFF")
+        XCTAssertEqual(HexColor.mixed(hex: "#FFFFFF", amount: -5.0), "#000000")
+    }
+
+    func testMixedReturnsInputOnParseFailure() {
+        XCTAssertEqual(HexColor.mixed(hex: "garbage", amount: 0.3), "garbage")
+    }
+
+    func testShadedAlternatesLightAndDark() {
+        let base = "#808080" // 中間グレー
+        let shade0 = HexColor.shaded(parentHex: base, childIndex: 0)
+        let shade1 = HexColor.shaded(parentHex: base, childIndex: 1)
+        // index 0 は明寄り、 index 1 は暗寄り
+        XCTAssertGreaterThan(brightness(of: shade0), brightness(of: base))
+        XCTAssertLessThan(brightness(of: shade1), brightness(of: base))
+    }
+
+    private func brightness(of hex: String) -> Double {
+        guard let rgb = HexColor.parse(hex: hex) else { return 0 }
+        return (rgb.red + rgb.green + rgb.blue) / 3.0
+    }
+}

--- a/ios/Shared/HexColor.swift
+++ b/ios/Shared/HexColor.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// 6 桁 hex 文字列ベースの色操作ユーティリティ。
+///
+/// SwiftUI の `Color` には HSB 取り出し API がない (UIColor 経由で取れるが
+/// `Shared/` は AppKit/UIKit 非依存にしておきたい)。ここでは RGB 同士の線形
+/// 補間で「白 / 黒に寄せたシェード」を作る。
+enum HexColor {
+    struct RGB: Equatable {
+        let red: Double
+        let green: Double
+        let blue: Double
+    }
+
+    /// `amount` (>0 で白寄り、<0 で黒寄り、[-1, 1]) で色をブレンドした hex を返す。
+    /// パースに失敗したら入力をそのまま返す。
+    static func mixed(hex: String, amount: Double) -> String {
+        guard let rgb = parse(hex: hex) else { return hex }
+        let clamped = max(-1, min(1, amount))
+        let target: Double = clamped >= 0 ? 1.0 : 0.0
+        let weight = abs(clamped)
+        let red = rgb.red + (target - rgb.red) * weight
+        let green = rgb.green + (target - rgb.green) * weight
+        let blue = rgb.blue + (target - rgb.blue) * weight
+        return format(red: red, green: green, blue: blue)
+    }
+
+    /// 親の色から、子の sortOrder 位置 (0始まり) で連続的にずらしたシェード hex を返す。
+    /// 偶数 index → 明、奇数 index → 暗を交互に重ねる。
+    static func shaded(parentHex: String, childIndex: Int) -> String {
+        let step = 0.18
+        let magnitude = Double((childIndex / 2) + 1) * step
+        let lighter = childIndex % 2 == 0
+        let amount = lighter ? magnitude : -magnitude
+        return mixed(hex: parentHex, amount: amount)
+    }
+
+    static func parse(hex: String) -> RGB? {
+        var trimmed = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("#") {
+            trimmed.removeFirst()
+        }
+        guard trimmed.count == 6, let value = UInt32(trimmed, radix: 16) else {
+            return nil
+        }
+        return RGB(
+            red: Double((value >> 16) & 0xFF) / 255,
+            green: Double((value >> 8) & 0xFF) / 255,
+            blue: Double(value & 0xFF) / 255
+        )
+    }
+
+    private static func format(red: Double, green: Double, blue: Double) -> String {
+        let rInt = Int((red * 255).rounded())
+        let gInt = Int((green * 255).rounded())
+        let bInt = Int((blue * 255).rounded())
+        return String(format: "#%02X%02X%02X", rInt, gInt, bInt)
+    }
+}


### PR DESCRIPTION
## Summary
- `Shared/HexColor.swift` を新規追加 (白/黒ブレンド + 親色からの濃淡シェード生成)
- `PeriodActivitySummary` / `DayActivitySummary` で子テンプレの表示色を **親色 + sortOrder の濃淡** に置き換え
- `CategoryBarChart` に凡例 (色チップ + 名称 + 合計時間) を追加

## 仕様根拠 (#53)
- **親テンプレ (ジャンル) ごとに色** / 子は濃淡で区別 (確定済み)
- グラフ要素にラベル/凡例を表示 (確定済み)

## Test plan
- [x] `make test` 88 件 (HexColor 7件追加)
- [x] `make lint --strict` 0 violations
- [x] `make format-check` OK