### PR TITLE
feat: 統計サマリーを縦棒グラフに変更 (#55)

### DIFF
--- a/ios/DailyLog/Views/Stats/CategoryBarChart.swift
+++ b/ios/DailyLog/Views/Stats/CategoryBarChart.swift
@@ -15,11 +15,11 @@ struct CategoryBarChart: View {
         Chart {
             ForEach(categories) { category in
                 BarMark(
-                    x: .value("時間", category.totalSeconds / 3600),
-                    y: .value("カテゴリ", category.templateName)
+                    x: .value("カテゴリ", category.templateName),
+                    y: .value("時間", category.totalSeconds / 3600)
                 )
                 .foregroundStyle(Color(hex: category.colorHex) ?? .accentColor)
-                .annotation(position: .trailing, alignment: .leading) {
+                .annotation(position: .top, alignment: .center) {
                     Text(DurationFormatter.elapsed(seconds: Int(category.totalSeconds)))
                         .font(.caption2)
                         .foregroundStyle(.secondary)
@@ -28,6 +28,18 @@ struct CategoryBarChart: View {
         }
         .chartXAxis {
             AxisMarks(values: .automatic) { value in
+                AxisValueLabel {
+                    if let name = value.as(String.self) {
+                        Text(name)
+                            .font(.caption2)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                }
+            }
+        }
+        .chartYAxis {
+            AxisMarks(position: .leading, values: .automatic) { value in
                 AxisGridLine()
                 AxisValueLabel {
                     if let hours = value.as(Double.self) {
@@ -36,9 +48,7 @@ struct CategoryBarChart: View {
                 }
             }
         }
-        .chartYAxis {
-            AxisMarks(position: .leading)
-        }
+        .frame(minHeight: 220)
     }
 
     private var legend: some View {

--- a/ios/DailyLog/Views/Stats/PeriodStatsView.swift
+++ b/ios/DailyLog/Views/Stats/PeriodStatsView.swift
@@ -115,7 +115,6 @@ struct PeriodStatsView: View {
                     .foregroundStyle(.secondary)
             } else {
                 CategoryBarChart(categories: displayCategories)
-                    .frame(minHeight: CGFloat(displayCategories.count * 36 + 40))
 
                 ForEach(displayCategories) { category in
                     CategoryRow(


### PR DESCRIPTION
## Summary
- CategoryBarChart の BarMark を縦棒 (X=カテゴリ, Y=時間 [h]) に切替
- 棒の上に経過時間を annotation 表示
- PeriodStatsView の minHeight 自動計算を削除

## 仕様根拠 (#55)
- X=タスク / Y=期間合計時間 (確定済み)

## Test plan
- [x] `make test` 88 件パス
- [x] `make lint --strict` 0 violations
- [x] `make format-check` OK