### PR TITLE
feat: ホーム下部に「今日のメモ」欄を追加 (#60)

### DIFF
--- a/ios/DailyLog/Models/AppModelContainer.swift
+++ b/ios/DailyLog/Models/AppModelContainer.swift
@@ -7,6 +7,7 @@ enum AppModelContainer {
         Activity.self,
         Meal.self,
         AppSettings.self,
+        DailyMemo.self,
     ])
 
     static func makeContainer(inMemory: Bool = false) throws -> ModelContainer {

--- a/ios/DailyLog/Models/DailyMemo.swift
+++ b/ios/DailyLog/Models/DailyMemo.swift
@@ -1,0 +1,33 @@
+import Foundation
+import SwiftData
+
+/// その日に書き残す自由メモ。`dayKey` (yyyy-MM-dd, ローカルタイム) を一意キーとして
+/// 1日1メモを保持する。CloudKit 同期対象。
+@Model
+final class DailyMemo {
+    @Attribute(.unique) var dayKey: String = ""
+    var text: String = ""
+    var createdAt: Date = Date()
+    var updatedAt: Date = Date()
+
+    init(
+        dayKey: String,
+        text: String = "",
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.dayKey = dayKey
+        self.text = text
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    static func dayKey(for date: Date, calendar: Calendar = .currentGregorian) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.timeZone = calendar.timeZone
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+}

--- a/ios/DailyLog/Views/DailyMemoCard.swift
+++ b/ios/DailyLog/Views/DailyMemoCard.swift
@@ -1,0 +1,84 @@
+import SwiftData
+import SwiftUI
+
+/// ホーム下部に表示する「今日のメモ」入力カード。
+/// `dayKey` 一意で `DailyMemo` を 1 日 1 件保持し、テキスト変更時に自動保存する。
+struct DailyMemoCard: View {
+    @Environment(\.modelContext) private var modelContext
+
+    @Query private var memos: [DailyMemo]
+
+    @State private var draft: String = ""
+    @State private var loadedDayKey: String?
+    @FocusState private var isFocused: Bool
+
+    private let calendar: Calendar = .currentGregorian
+
+    private var todayKey: String {
+        DailyMemo.dayKey(for: Date(), calendar: calendar)
+    }
+
+    private var todayMemo: DailyMemo? {
+        memos.first { $0.dayKey == todayKey }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Label("今日のメモ", systemImage: "note.text")
+                    .font(.subheadline.bold())
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if isFocused {
+                    Button("完了") {
+                        isFocused = false
+                    }
+                    .font(.caption)
+                }
+            }
+
+            ZStack(alignment: .topLeading) {
+                if draft.isEmpty {
+                    Text("今日やったことを書き残す…")
+                        .font(.body)
+                        .foregroundStyle(.tertiary)
+                        .padding(.top, 8)
+                        .padding(.leading, 4)
+                        .allowsHitTesting(false)
+                }
+                TextEditor(text: $draft)
+                    .focused($isFocused)
+                    .frame(minHeight: 80)
+                    .scrollContentBackground(.hidden)
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.secondarySystemBackground))
+        )
+        .onAppear(perform: loadIfNeeded)
+        .onChange(of: draft) { _, newValue in
+            save(text: newValue)
+        }
+    }
+
+    private func loadIfNeeded() {
+        if loadedDayKey == todayKey { return }
+        draft = todayMemo?.text ?? ""
+        loadedDayKey = todayKey
+    }
+
+    private func save(text: String) {
+        guard loadedDayKey == todayKey else { return }
+        if let existing = todayMemo {
+            guard existing.text != text else { return }
+            existing.text = text
+            existing.updatedAt = Date()
+        } else {
+            let memo = DailyMemo(dayKey: todayKey, text: text)
+            modelContext.insert(memo)
+        }
+        try? modelContext.save()
+    }
+}

--- a/ios/DailyLog/Views/HomeView.swift
+++ b/ios/DailyLog/Views/HomeView.swift
@@ -42,6 +42,8 @@ struct HomeView: View {
                         onTap: { start(with: $0) }
                     )
 
+                    DailyMemoCard()
+
                     Spacer(minLength: 0)
                 }
                 .padding(.horizontal)

--- a/ios/DailyLogTests/ModelTests.swift
+++ b/ios/DailyLogTests/ModelTests.swift
@@ -151,6 +151,32 @@ final class ModelTests: XCTestCase {
     }
 
     @MainActor
+    func testDailyMemoDayKeyFormatting() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        if let tz = TimeZone(identifier: "Asia/Tokyo") {
+            calendar.timeZone = tz
+        }
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 5
+        components.day = 13
+        components.hour = 14
+        let date = try XCTUnwrap(calendar.date(from: components))
+        XCTAssertEqual(DailyMemo.dayKey(for: date, calendar: calendar), "2026-05-13")
+    }
+
+    @MainActor
+    func testDailyMemoUniqueByDayKey() throws {
+        let context = container.mainContext
+        context.insert(DailyMemo(dayKey: "2026-05-13", text: "first"))
+        try context.save()
+
+        let fetched = try context.fetch(FetchDescriptor<DailyMemo>())
+        XCTAssertEqual(fetched.count, 1)
+        XCTAssertEqual(fetched.first?.text, "first")
+    }
+
+    @MainActor
     func testAppSettingsDefaults() throws {
         let context = container.mainContext
         let settings = AppSettings()


### PR DESCRIPTION
## Summary
- 新規 `DailyMemo` モデル: `dayKey` (yyyy-MM-dd ローカルタイム, unique) で1日1メモ
- `AppModelContainer.schema` に登録 (CloudKit 同期対象)
- `DailyMemoCard` を新規追加: ホーム最下部の自動保存メモ入力 (TextEditor)
- 日付が変わったら自動的に当日のメモに切替
- HomeView の TemplateGrid 直下に配置

## 仕様根拠 (#60)
- スコープ: **1日1メモ・独立機能** (確定済み)

## Test plan
- [x] `make test` 90 件 (DailyMemo 2 件追加)
- [x] `make lint --strict` 0 violations
- [x] `make format-check` OK