### PR TITLE
fix: Live Activity がロック画面に残らない競合を解消 (#70)

### DIFF
--- a/ios/DailyLog/Services/ActivityService.swift
+++ b/ios/DailyLog/Services/ActivityService.swift
@@ -38,10 +38,19 @@ struct ActivityService {
         // 過去分を await で片付けてから新規 Live Activity を request する。
         // 順序が逆だと、新規作成直後の endAll が今作ったものまで end してしまい、
         // ロック画面から消える (Issue #70)。
+        // Task に SwiftData モデルを掴ませないため、ここで value snapshot を取る
+        // (テスト等でコンテナが破棄された後の参照→fatal を避ける)。
+        let templateName = template.name
+        let iconName = template.iconName
+        let colorHex = template.colorHex
+        let isMealType = template.isMealType
         Task { @MainActor in
             await LiveActivityController.shared.endAll()
             LiveActivityController.shared.start(
-                template: template,
+                templateName: templateName,
+                iconName: iconName,
+                colorHex: colorHex,
+                isMealType: isMealType,
                 startAt: now,
                 nextCandidates: candidates
             )

--- a/ios/DailyLog/Services/ActivityService.swift
+++ b/ios/DailyLog/Services/ActivityService.swift
@@ -35,12 +35,17 @@ struct ActivityService {
             notifier.scheduleReminder(for: activity)
         }
         publishSnapshot(for: activity)
-        Task { await LiveActivityController.shared.endAll() }
-        LiveActivityController.shared.start(
-            template: template,
-            startAt: now,
-            nextCandidates: candidates
-        )
+        // 過去分を await で片付けてから新規 Live Activity を request する。
+        // 順序が逆だと、新規作成直後の endAll が今作ったものまで end してしまい、
+        // ロック画面から消える (Issue #70)。
+        Task { @MainActor in
+            await LiveActivityController.shared.endAll()
+            LiveActivityController.shared.start(
+                template: template,
+                startAt: now,
+                nextCandidates: candidates
+            )
+        }
         return activity
     }
 

--- a/ios/DailyLog/Services/LiveActivityController.swift
+++ b/ios/DailyLog/Services/LiveActivityController.swift
@@ -1,5 +1,6 @@
 import ActivityKit
 import Foundation
+import os.log
 
 /// 行動開始/停止に連動して ActivityKit の Live Activity を制御する。
 ///
@@ -9,8 +10,13 @@ import Foundation
 struct LiveActivityController {
     static let shared = LiveActivityController()
 
+    private static let log = Logger(subsystem: "com.coco.daily-log", category: "LiveActivity")
+
     func start(template: ActivityTemplate, startAt: Date, nextCandidates: [NextActionCandidate] = []) {
-        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+            Self.log.info("areActivitiesEnabled=false — Live Activity をスキップ。設定>DailyLog>Live Activities を確認。")
+            return
+        }
 
         let attributes = DailyLogActivityAttributes(
             templateName: template.name,
@@ -25,13 +31,17 @@ struct LiveActivityController {
         let content = ActivityContent(state: state, staleDate: nil)
 
         do {
-            _ = try ActivityKit.Activity<DailyLogActivityAttributes>.request(
+            let activity = try ActivityKit.Activity<DailyLogActivityAttributes>.request(
                 attributes: attributes,
                 content: content,
                 pushType: nil
             )
+            Self.log
+                .info(
+                    "Live Activity 開始: id=\(activity.id, privacy: .public) template=\(template.name, privacy: .public)"
+                )
         } catch {
-            // ユーザー拒否など。失敗は silent (アプリ本体は動作継続)。
+            Self.log.error("Live Activity の request に失敗: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/ios/DailyLog/Services/LiveActivityController.swift
+++ b/ios/DailyLog/Services/LiveActivityController.swift
@@ -6,23 +6,34 @@ import os.log
 ///
 /// `ActivityKit.Activity` と SwiftData の `Activity` クラスが同名なので、
 /// 明示的なフルパスで参照する。
+///
+/// API は SwiftData モデルではなく value-type のパラメータを受け取る。
+/// 非同期で利用する場面 (Task で endAll → start の直列化) で、呼び出し元の
+/// 寿命が切れた managed object に依存しないようにするため。
 @MainActor
 struct LiveActivityController {
     static let shared = LiveActivityController()
 
     private static let log = Logger(subsystem: "com.coco.daily-log", category: "LiveActivity")
 
-    func start(template: ActivityTemplate, startAt: Date, nextCandidates: [NextActionCandidate] = []) {
+    func start(
+        templateName: String,
+        iconName: String,
+        colorHex: String,
+        isMealType: Bool,
+        startAt: Date,
+        nextCandidates: [NextActionCandidate] = []
+    ) {
         guard ActivityAuthorizationInfo().areActivitiesEnabled else {
             Self.log.info("areActivitiesEnabled=false — Live Activity をスキップ。設定>DailyLog>Live Activities を確認。")
             return
         }
 
         let attributes = DailyLogActivityAttributes(
-            templateName: template.name,
-            iconName: template.iconName,
-            colorHex: template.colorHex,
-            isMealType: template.isMealType
+            templateName: templateName,
+            iconName: iconName,
+            colorHex: colorHex,
+            isMealType: isMealType
         )
         let state = DailyLogActivityAttributes.ContentState(
             startAt: startAt,
@@ -38,7 +49,7 @@ struct LiveActivityController {
             )
             Self.log
                 .info(
-                    "Live Activity 開始: id=\(activity.id, privacy: .public) template=\(template.name, privacy: .public)"
+                    "Live Activity 開始: id=\(activity.id, privacy: .public) template=\(templateName, privacy: .public)"
                 )
         } catch {
             Self.log.error("Live Activity の request に失敗: \(error.localizedDescription, privacy: .public)")


### PR DESCRIPTION
## 症状
ロック画面で Live Activity が表示されない (タイマーアプリのようには出てこない)。

## 原因
\`ActivityService.start\` の終盤、

\`\`\`swift
Task { await LiveActivityController.shared.endAll() }
LiveActivityController.shared.start(...)
\`\`\`

別 Task に投げた endAll が新規 start の後に走り、今作ったばかりの Live Activity も \`activities\` に含まれて end されてしまう。

## 修正
- start 内の Task で endAll を \`await\` してから start する直列化
- \`LiveActivityController\` に os.log を追加し \`areActivitiesEnabled=false\` や request 失敗を console に残す (次回の診断用)

## Test plan
- [x] \`make test\` 90 件パス
- [x] \`make lint --strict\` 0 violations
- [x] \`make format-check\` OK
- [ ] 実機: アクション開始→ロックすると Live Activity が常時表示される

Closes #70