### PR TITLE
fix: Asset Symbol Extensions の build setting 名を正しいものに

### DIFF
--- a/ios/project.yml
+++ b/ios/project.yml
@@ -29,9 +29,10 @@ settings:
     # Xcode 16+ で増えた "Enable String Catalog Symbol Generation" 推奨設定。
     LOCALIZED_STRING_SWIFTUI_SUPPORT: YES
     STRING_CATALOG_GENERATE_SYMBOLS: YES
-    # Xcode 16+ "Enable Generated Asset Symbol Extensions" 推奨設定。
+    # Xcode 16+ "Generate Swift Asset Symbol Extensions" 推奨設定。
     # Assets.xcassets 内の色/画像を Image(.foo) のように型安全に参照できる。
-    ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOL_EXTENSIONS: YES
+    # build setting 名は xcspec で `ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS`。
+    ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS: YES
     # CODE_SIGN_STYLE と DEVELOPMENT_TEAM は Signing.xcconfig 側で管理。
     # project.yml 側で `DEVELOPMENT_TEAM: ""` を書くと xcconfig の値を空文字で上書きしてしまう。
 


### PR DESCRIPTION
## Summary
- #74 (#75) で追加した \`ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOL_EXTENSIONS\` は誤った名前で、Xcode の警告が消えていなかった
- Xcode の \`AssetCatalogCompiler.xcspec\` を確認したところ、DisplayName "Generate Swift Asset Symbol Extensions" に対応する正しい build setting 名は **\`ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS\`** (SWIFT が真ん中に入る)
- これに置き換え

## Test plan
- [x] \`make generate && make build\` 通過
- [ ] Xcode を開き直して Update to recommended settings ダイアログが消えていること