### PR TITLE
feat: 週ビューのセグメント吹き出しと時間軸の上下反転

### DIFF
--- a/ios/DailyLog/Utilities/WeekActivityLayout.swift
+++ b/ios/DailyLog/Utilities/WeekActivityLayout.swift
@@ -10,6 +10,8 @@ enum WeekActivityLayout {
         let endHours: Double // startHours < endHours ≤ 24.0
         let colorHex: String
         let templateName: String
+        let startDate: Date // このチャンクの実開始時刻
+        let endDate: Date // このチャンクの実終了時刻
     }
 
     /// 指定週内の Activity を Span 配列に変換する。
@@ -58,7 +60,9 @@ enum WeekActivityLayout {
                         startHours: startHours,
                         endHours: endHours,
                         colorHex: activity.template?.colorHex ?? "#7F8C8D",
-                        templateName: activity.template?.name ?? "—"
+                        templateName: activity.template?.name ?? "—",
+                        startDate: cursor,
+                        endDate: chunkEnd
                     )
                 )
 

--- a/ios/DailyLog/Views/Stats/WeekActivityChart.swift
+++ b/ios/DailyLog/Views/Stats/WeekActivityChart.swift
@@ -6,17 +6,28 @@ struct WeekActivityChart: View {
     let spans: [WeekActivityLayout.Span]
     let weekdayLabels: [String]
 
+    @State private var selectedSpanID: UUID?
+
+    private var selectedSpan: WeekActivityLayout.Span? {
+        spans.first { $0.id == selectedSpanID }
+    }
+
     var body: some View {
         Chart {
             ForEach(spans) { span in
+                let xStart = Double(span.weekdayIndex) - 0.4
+                let xEnd = Double(span.weekdayIndex) + 0.4
+                // 上=00:00, 下=24:00 にするため (24 - hours) に変換してプロットする。
+                let yStart: Double = 24 - span.endHours
+                let yEnd: Double = 24 - span.startHours
                 RectangleMark(
-                    xStart: .value("start-day", Double(span.weekdayIndex) - 0.4),
-                    xEnd: .value("end-day", Double(span.weekdayIndex) + 0.4),
-                    yStart: .value("start-hour", span.startHours),
-                    yEnd: .value("end-hour", span.endHours)
+                    xStart: .value("start-day", xStart),
+                    xEnd: .value("end-day", xEnd),
+                    yStart: .value("start-hour", yStart),
+                    yEnd: .value("end-hour", yEnd)
                 )
                 .foregroundStyle(Color(hex: span.colorHex) ?? .accentColor)
-                .opacity(0.85)
+                .opacity(selectedSpanID == nil || selectedSpanID == span.id ? 0.95 : 0.4)
             }
         }
         .chartXScale(domain: -0.5 ... 6.5)
@@ -31,8 +42,9 @@ struct WeekActivityChart: View {
                 AxisGridLine()
                 AxisTick()
                 AxisValueLabel {
-                    if let hour = value.as(Double.self) {
-                        Text(String(format: "%02d:00", Int(hour)))
+                    if let plotted = value.as(Double.self) {
+                        // プロット値は反転済みなので元の時刻は (24 - plotted)。
+                        Text(String(format: "%02d:00", Int(24 - plotted)))
                             .font(.caption2)
                     }
                 }
@@ -45,6 +57,79 @@ struct WeekActivityChart: View {
                         .fill(Color(.secondarySystemBackground))
                 )
         }
+        .chartOverlay { proxy in
+            GeometryReader { geo in
+                tapTarget(proxy: proxy, geo: geo)
+                if let span = selectedSpan {
+                    callout(for: span, proxy: proxy, geo: geo)
+                }
+            }
+        }
+    }
+
+    private func tapTarget(proxy: ChartProxy, geo: GeometryProxy) -> some View {
+        Rectangle()
+            .fill(.clear)
+            .contentShape(Rectangle())
+            .onTapGesture { location in
+                handleTap(at: location, proxy: proxy, geo: geo)
+            }
+    }
+
+    private func handleTap(at location: CGPoint, proxy: ChartProxy, geo: GeometryProxy) {
+        guard let plotAnchor = proxy.plotFrame else { return }
+        let origin = geo[plotAnchor].origin
+        guard
+            let xValue: Double = proxy.value(atX: location.x - origin.x),
+            let yValue: Double = proxy.value(atY: location.y - origin.y)
+        else { return }
+        let hour = 24 - yValue
+        let dayIndex = Int(xValue.rounded())
+        let hit = spans.first { span in
+            span.weekdayIndex == dayIndex && hour >= span.startHours && hour <= span.endHours
+        }
+        withAnimation(.easeOut(duration: 0.15)) {
+            selectedSpanID = (hit?.id == selectedSpanID) ? nil : hit?.id
+        }
+    }
+
+    @ViewBuilder
+    private func callout(for span: WeekActivityLayout.Span, proxy: ChartProxy, geo: GeometryProxy) -> some View {
+        if let point = calloutPoint(for: span, proxy: proxy, geo: geo) {
+            CalloutBubble(
+                title: span.templateName,
+                timeRange: timeRangeText(for: span),
+                duration: durationText(for: span)
+            )
+            .position(x: point.x, y: point.y)
+            .allowsHitTesting(false)
+        }
+    }
+
+    private func calloutPoint(
+        for span: WeekActivityLayout.Span,
+        proxy: ChartProxy,
+        geo: GeometryProxy
+    ) -> CGPoint? {
+        guard
+            let plotAnchor = proxy.plotFrame,
+            let xPos = proxy.position(forX: Double(span.weekdayIndex)),
+            let yPos = proxy.position(forY: 24 - (span.startHours + span.endHours) / 2)
+        else { return nil }
+        let origin = geo[plotAnchor].origin
+        return CGPoint(x: origin.x + xPos, y: origin.y + yPos)
+    }
+
+    private func timeRangeText(for span: WeekActivityLayout.Span) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.dateFormat = "HH:mm"
+        return "\(formatter.string(from: span.startDate)) – \(formatter.string(from: span.endDate))"
+    }
+
+    private func durationText(for span: WeekActivityLayout.Span) -> String {
+        let seconds = Int(span.endDate.timeIntervalSince(span.startDate))
+        return DurationFormatter.elapsed(seconds: seconds)
     }
 
     @ViewBuilder
@@ -56,5 +141,38 @@ struct WeekActivityChart: View {
                     .font(.caption)
             }
         }
+    }
+}
+
+/// セグメントタップ時に表示する吹き出し。
+private struct CalloutBubble: View {
+    let title: String
+    let timeRange: String
+    let duration: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.caption.bold())
+                .lineLimit(1)
+            Text(timeRange)
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.secondary)
+            Text(duration)
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color(.systemBackground))
+                .shadow(color: .black.opacity(0.2), radius: 4, y: 1)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(.separator), lineWidth: 0.5)
+        )
+        .fixedSize()
     }
 }

--- a/ios/DailyLogTests/WeekActivityLayoutTests.swift
+++ b/ios/DailyLogTests/WeekActivityLayoutTests.swift
@@ -21,6 +21,22 @@ final class WeekActivityLayoutTests: XCTestCase {
         XCTAssertEqual(span.weekdayIndex, 3) // Sun=0, ..., Wed=3
         XCTAssertEqual(span.startHours, 14, accuracy: 0.001)
         XCTAssertEqual(span.endHours, 16.5, accuracy: 0.001)
+        XCTAssertEqual(span.startDate, date(2026, 4, 22, 14, 0))
+        XCTAssertEqual(span.endDate, date(2026, 4, 22, 16, 30))
+    }
+
+    func testMidnightSplitChunkDatesAreClippedToEachDay() {
+        let weekStart = sunday(2026, 4, 19)
+        // Monday 22:00 -> Tuesday 01:00
+        let activity = makeActivity(start: date(2026, 4, 20, 22, 0), duration: 3 * 3600)
+
+        let spans = WeekActivityLayout.spans(for: [activity], weekStart: weekStart, calendar: calendar)
+
+        XCTAssertEqual(spans.count, 2)
+        XCTAssertEqual(spans[0].startDate, date(2026, 4, 20, 22, 0))
+        XCTAssertEqual(spans[0].endDate, date(2026, 4, 21, 0, 0))
+        XCTAssertEqual(spans[1].startDate, date(2026, 4, 21, 0, 0))
+        XCTAssertEqual(spans[1].endDate, date(2026, 4, 21, 1, 0))
     }
 
     func testActivitySpanningMidnightSplitsAcrossDays() {


### PR DESCRIPTION
## 概要
統計の週ビュー(24時間カラーバー)を改善。統計改善シリーズの PR1。

## 変更点
- カラーバーの各セグメントをタップするとアクション名/時刻レンジ/所要時間を吹き出し表示
  - 同じセグメント再タップで畳む
  - 別セグメントをタップすると前の吹き出しを閉じて新しいものを表示
  - チャート外をタップで閉じる
- 時間軸を上=24:00 から **上=00:00 / 下=24:00** に反転(直感的な並び)
  - Swift Charts は連続スケールの反転 domain を直接扱えないため `24 - hours` 変換で実現
- `WeekActivityLayout.Span` に `startDate`/`endDate`(チャンクの実時刻)を追加し吹き出しの時刻表示に利用

## テスト
- `WeekActivityLayoutTests` に startDate/endDate の検証(単日・日跨ぎ分割)を追加
- ローカルで `xcodebuild test` 全91テスト green

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)