### PR TITLE
fix: 日別サマリーの日跨ぎ合計を24h以内にし内訳を時系列→割合順に

### DIFF
--- a/ios/DailyLog/Views/Calendar/DayDetailView.swift
+++ b/ios/DailyLog/Views/Calendar/DayDetailView.swift
@@ -9,11 +9,11 @@ struct DayDetailView: View {
     @Query(sort: \Activity.startAt)
     private var allActivities: [Activity]
 
-    @State private var chartMode: ChartMode = .proportion
+    @State private var chartMode: ChartMode = .timeline
 
     enum ChartMode: String, CaseIterable, Identifiable {
-        case proportion
         case timeline
+        case proportion
 
         var id: String {
             rawValue
@@ -21,8 +21,8 @@ struct DayDetailView: View {
 
         var displayName: String {
             switch self {
-            case .proportion: "割合"
             case .timeline: "時系列"
+            case .proportion: "割合"
             }
         }
     }
@@ -84,10 +84,10 @@ struct DayDetailView: View {
         return formatter.string(from: date)
     }
 
+    /// 合計は日内にクリップ済みの slices から算出する。
+    /// 日付を跨ぐアクションは当日分のみ計上されるため 24 時間を超えない。
     private var totalDurationText: String {
-        let seconds = activities.reduce(0) { running, activity in
-            running + Int(activity.duration ?? 0)
-        }
+        let seconds = slices.reduce(0) { $0 + Int($1.totalSeconds) }
         return DurationFormatter.elapsed(seconds: seconds)
     }
 }

--- a/ios/DailyLogTests/DayActivitySummaryTests.swift
+++ b/ios/DailyLogTests/DayActivitySummaryTests.swift
@@ -46,6 +46,20 @@ final class DayActivitySummaryTests: XCTestCase {
         XCTAssertEqual(slices[0].totalSeconds, 2 * 3600, accuracy: 0.001)
     }
 
+    func testFullDaySpanningActivityCountsAtMost24Hours() {
+        let sleep = ActivityTemplate(name: "睡眠", colorHex: "#111111")
+        let day = date(2026, 4, 25)
+        // 2026-04-24 22:00 -> 2026-04-26 06:00 (32h total) covers all of day 25.
+        let activity = makeActivity(template: sleep, start: date(2026, 4, 24, 22, 0), duration: 32 * 3600)
+
+        let slices = DayActivitySummary.slices(for: [activity], on: day, calendar: calendar)
+        let total = slices.reduce(0) { $0 + $1.totalSeconds }
+
+        XCTAssertEqual(slices.count, 1)
+        XCTAssertEqual(slices[0].totalSeconds, 24 * 3600, accuracy: 0.001)
+        XCTAssertLessThanOrEqual(total, 24 * 3600)
+    }
+
     func testInProgressClipsToNow() {
         let work = ActivityTemplate(name: "仕事", colorHex: "#111111")
         let day = date(2026, 4, 25)


### PR DESCRIPTION
## 概要
日別サマリー画面の集計と表示順を改善。統計改善シリーズの PR4。

## 変更点
- **日跨ぎ合計の修正**: 合計時間を `activity.duration` の単純合算から**日内クリップ済みの `DayActivitySummary.slices` 合計**に変更。日付を跨ぐアクションは当日分のみ計上され、合計が24時間を超えない
- **内訳の順序入替**: 円グラフの並びを「割合→時系列」から**「時系列→割合」**に変更(初期表示も時系列)

## テスト
- 32h に渡る日跨ぎアクションが当日24hにクリップされ合計が24hを超えないことを検証するテストを追加
- ローカルで `xcodebuild test` 全95テスト green

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)