### PR TITLE
feat: 日別サマリーに手動修正機能と重複の上書き解決を追加

### DIFF
--- a/ios/DailyLog/Utilities/ActivityOverlapResolver.swift
+++ b/ios/DailyLog/Utilities/ActivityOverlapResolver.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// 1 日分の編集対象セグメント。`Activity` から切り出した値型 (テスト可能)。
+struct EditableSegment: Identifiable, Equatable {
+    let id: UUID // 元 Activity.id
+    var start: Date
+    var end: Date
+    let templateName: String
+    let colorHex: String
+
+    var duration: TimeInterval {
+        end.timeIntervalSince(start)
+    }
+}
+
+/// アクションの時刻を変更したときの重複を「上書き (トリム + 完全被覆は削除)」で解消する純ロジック。
+///
+/// 編集対象 X を新区間 `[start, end]` にしたとき、同日の他セグメント Y それぞれを:
+/// - 完全被覆 (Y が X 内に収まる) → 削除
+/// - 左重なり (Y が X より前から始まる) → `Y.end = X.start` にトリム
+/// - 右重なり (Y が X より後ろまで続く) → `Y.start = X.end` にトリム
+/// - Y が X を内包 → 早い側を残し `Y.end = X.start` にトリム (後半は破棄)
+/// - トリム結果が長さ 0 以下 → 削除
+/// これにより終了時刻を大きく後ろにずらして後続複数に被っても、被覆分は削除・部分重なりは
+/// トリムで解消され、後続が黙って潰れることがない。
+enum ActivityOverlapResolver {
+    struct Resolution: Equatable {
+        /// 時刻調整後のセグメント (編集対象を含む)。元の並び順を保持。
+        var updated: [EditableSegment]
+        /// 完全被覆/0 長で削除されたセグメントの ID。
+        var deletedIDs: [UUID]
+    }
+
+    /// `editedID` を `newStart`/`newEnd` に変更し、重複を解消した結果を返す。
+    /// `newStart < newEnd` を前提とする (呼び出し側でクランプ)。
+    static func apply(
+        editedID: UUID,
+        newStart: Date,
+        newEnd: Date,
+        to segments: [EditableSegment]
+    ) -> Resolution {
+        var updated: [EditableSegment] = []
+        var deletedIDs: [UUID] = []
+
+        for segment in segments {
+            if segment.id == editedID {
+                var edited = segment
+                edited.start = newStart
+                edited.end = newEnd
+                updated.append(edited)
+                continue
+            }
+
+            guard overlaps(segment, newStart: newStart, newEnd: newEnd) else {
+                updated.append(segment)
+                continue
+            }
+
+            let startsBefore = segment.start < newStart
+            let endsAfter = segment.end > newEnd
+            var trimmed = segment
+
+            switch (startsBefore, endsAfter) {
+            case (true, true), (true, false):
+                // Y が X を内包 or 左重なり → 左側を残す
+                trimmed.end = newStart
+            case (false, true):
+                // 右重なり → 右側を残す
+                trimmed.start = newEnd
+            case (false, false):
+                // 完全被覆 → 削除
+                deletedIDs.append(segment.id)
+                continue
+            }
+
+            if trimmed.end > trimmed.start {
+                updated.append(trimmed)
+            } else {
+                deletedIDs.append(segment.id)
+            }
+        }
+
+        return Resolution(updated: updated, deletedIDs: deletedIDs)
+    }
+
+    private static func overlaps(_ segment: EditableSegment, newStart: Date, newEnd: Date) -> Bool {
+        segment.start < newEnd && segment.end > newStart
+    }
+}

--- a/ios/DailyLog/Views/Calendar/DayDetailView.swift
+++ b/ios/DailyLog/Views/Calendar/DayDetailView.swift
@@ -10,6 +10,7 @@ struct DayDetailView: View {
     private var allActivities: [Activity]
 
     @State private var chartMode: ChartMode = .timeline
+    @State private var isEditing = false
 
     enum ChartMode: String, CaseIterable, Identifiable {
         case timeline
@@ -75,6 +76,15 @@ struct DayDetailView: View {
         }
         .navigationTitle(titleText)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("修正") { isEditing = true }
+                    .disabled(activities.isEmpty)
+            }
+        }
+        .sheet(isPresented: $isEditing) {
+            DayEditView(date: date)
+        }
     }
 
     private var titleText: String {

--- a/ios/DailyLog/Views/Calendar/DayEditView.swift
+++ b/ios/DailyLog/Views/Calendar/DayEditView.swift
@@ -1,0 +1,262 @@
+import SwiftData
+import SwiftUI
+
+/// その日の記録のミスを手動修正する画面。
+/// - 時系列ドーナツ (プレビュー / タップで選択)
+/// - 各記録の開始/終了時刻を ±5 分・±15 分ボタンで調整
+/// - 期間が他と被ったら `ActivityOverlapResolver` で上書き (トリム + 完全被覆は削除) 解消
+/// - 削除が発生する場合は保存前に確認
+struct DayEditView: View {
+    let date: Date
+
+    @Query(sort: \Activity.startAt)
+    private var allActivities: [Activity]
+
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var segments: [EditableSegment] = []
+    @State private var selectedID: UUID?
+    @State private var pendingDeleted: [EditableSegment] = []
+    @State private var excludedCount = 0
+    @State private var showDeleteConfirm = false
+    @State private var didPopulate = false
+
+    private let calendar: Calendar = .currentGregorian
+    private let now: Date = .init()
+
+    private var dayStart: Date {
+        calendar.startOfDay(for: date)
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 16) {
+                    TimelineEditorDonut(segments: segments, dayStart: dayStart, selectedID: $selectedID)
+                        .frame(height: 220)
+
+                    if excludedCount > 0 {
+                        Text("日をまたぐ / 進行中の記録は修正対象外です")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    content
+                }
+                .padding()
+            }
+            .navigationTitle("記録を修正")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar { toolbarContent }
+            .confirmationDialog("削除される記録があります", isPresented: $showDeleteConfirm, titleVisibility: .visible) {
+                Button("削除して保存", role: .destructive) { commit() }
+                Button("キャンセル", role: .cancel) {}
+            } message: {
+                Text(deleteMessage)
+            }
+            .onAppear(perform: populateIfNeeded)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if segments.isEmpty {
+            Text("修正できる記録がありません")
+                .foregroundStyle(.secondary)
+                .padding(.top, 40)
+        } else {
+            ForEach(segments) { segment in
+                DayEditRow(
+                    segment: segment,
+                    isSelected: selectedID == segment.id,
+                    onSelect: { selectedID = segment.id },
+                    onAdjustStart: { adjust(segment.id, startDelta: $0, endDelta: 0) },
+                    onAdjustEnd: { adjust(segment.id, startDelta: 0, endDelta: $0) }
+                )
+            }
+        }
+    }
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .cancellationAction) {
+            Button("キャンセル") { dismiss() }
+        }
+        ToolbarItem(placement: .confirmationAction) {
+            Button("保存") { save() }
+                .disabled(segments.isEmpty && pendingDeleted.isEmpty)
+        }
+    }
+
+    // MARK: - Editing
+
+    private func adjust(_ id: UUID, startDelta: TimeInterval, endDelta: TimeInterval) {
+        guard let current = segments.first(where: { $0.id == id }) else { return }
+        let dayEnd = dayStart.addingTimeInterval(86400)
+        let newStart = clamp(current.start.addingTimeInterval(startDelta), lower: dayStart, upper: dayEnd)
+        let newEnd = clamp(current.end.addingTimeInterval(endDelta), lower: dayStart, upper: dayEnd)
+        guard newEnd.timeIntervalSince(newStart) >= 60 else { return }
+
+        let before = segments
+        let result = ActivityOverlapResolver.apply(editedID: id, newStart: newStart, newEnd: newEnd, to: segments)
+        for deletedID in result.deletedIDs {
+            if let deleted = before.first(where: { $0.id == deletedID }) {
+                pendingDeleted.append(deleted)
+            }
+        }
+        selectedID = id
+        withAnimation { segments = result.updated }
+    }
+
+    private func clamp(_ date: Date, lower: Date, upper: Date) -> Date {
+        min(max(date, lower), upper)
+    }
+
+    // MARK: - Persistence
+
+    private func save() {
+        if pendingDeleted.isEmpty {
+            commit()
+        } else {
+            showDeleteConfirm = true
+        }
+    }
+
+    private func commit() {
+        let byID = Dictionary(allActivities.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        for segment in segments {
+            guard let activity = byID[segment.id] else { continue }
+            activity.startAt = segment.start
+            activity.endAt = segment.end
+        }
+        for id in Set(pendingDeleted.map(\.id)) {
+            if let activity = byID[id] {
+                modelContext.delete(activity)
+            }
+        }
+        try? modelContext.save()
+        dismiss()
+    }
+
+    private var deleteMessage: String {
+        let names = Set(pendingDeleted.map(\.templateName)).sorted()
+        return "次の記録が削除されます: \(names.joined(separator: "、"))"
+    }
+
+    // MARK: - Population
+
+    private func populateIfNeeded() {
+        guard !didPopulate else { return }
+        didPopulate = true
+
+        let dayEnd = dayStart.addingTimeInterval(86400)
+        let dayActivities = ActivityDateExtractor.activities(on: date, from: allActivities, calendar: calendar)
+            .sorted { $0.startAt < $1.startAt }
+
+        var built: [EditableSegment] = []
+        var excluded = 0
+        for activity in dayActivities {
+            // 安全のため当日内で完結する完了済み記録のみ編集対象とする。
+            guard let end = activity.endAt, activity.startAt >= dayStart, end <= dayEnd, end > activity.startAt else {
+                excluded += 1
+                continue
+            }
+            built.append(EditableSegment(
+                id: activity.id,
+                start: activity.startAt,
+                end: end,
+                templateName: activity.template?.name ?? "（未分類）",
+                colorHex: displayHex(for: activity.template)
+            ))
+        }
+        segments = built
+        excludedCount = excluded
+        selectedID = built.first?.id
+    }
+
+    private func displayHex(for template: ActivityTemplate?) -> String {
+        guard let template else { return "#7F8C8D" }
+        guard let parent = template.parent else { return template.colorHex }
+        let siblings = parent.children.sorted { $0.sortOrder < $1.sortOrder }
+        let index = siblings.firstIndex { $0.id == template.id } ?? 0
+        return HexColor.shaded(parentHex: parent.colorHex, childIndex: index)
+    }
+}
+
+private struct DayEditRow: View {
+    let segment: EditableSegment
+    let isSelected: Bool
+    let onSelect: () -> Void
+    let onAdjustStart: (TimeInterval) -> Void
+    let onAdjustEnd: (TimeInterval) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            header
+            timeControl(label: "開始", time: segment.start, onAdjust: onAdjustStart)
+            timeControl(label: "終了", time: segment.end, onAdjust: onAdjustEnd)
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(isSelected ? Color.accentColor.opacity(0.12) : Color(.secondarySystemBackground))
+        )
+        .contentShape(Rectangle())
+        .onTapGesture(perform: onSelect)
+    }
+
+    private var header: some View {
+        HStack {
+            Circle()
+                .fill(Color(hex: segment.colorHex) ?? .accentColor)
+                .frame(width: 12, height: 12)
+            Text(segment.templateName)
+                .font(.body)
+            Spacer()
+            Text(DurationFormatter.elapsed(seconds: Int(segment.duration)))
+                .font(.caption.monospacedDigit())
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func timeControl(
+        label: String,
+        time: Date,
+        onAdjust: @escaping (TimeInterval) -> Void
+    ) -> some View {
+        HStack(spacing: 6) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(width: 32, alignment: .leading)
+            Text(timeText(time))
+                .font(.subheadline.monospacedDigit())
+                .frame(width: 52, alignment: .leading)
+            Spacer()
+            stepButton("−15", -15 * 60, onAdjust)
+            stepButton("−5", -5 * 60, onAdjust)
+            stepButton("+5", 5 * 60, onAdjust)
+            stepButton("+15", 15 * 60, onAdjust)
+        }
+    }
+
+    private func stepButton(
+        _ title: String,
+        _ delta: TimeInterval,
+        _ onAdjust: @escaping (TimeInterval) -> Void
+    ) -> some View {
+        Button(title) { onAdjust(delta) }
+            .font(.caption.monospacedDigit())
+            .buttonStyle(.bordered)
+            .buttonBorderShape(.capsule)
+            .controlSize(.small)
+    }
+
+    private func timeText(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = .current
+        formatter.dateFormat = "HH:mm"
+        return formatter.string(from: date)
+    }
+}

--- a/ios/DailyLog/Views/Calendar/TimelineEditorDonut.swift
+++ b/ios/DailyLog/Views/Calendar/TimelineEditorDonut.swift
@@ -1,0 +1,108 @@
+import Darwin
+import SwiftUI
+
+/// 修正画面用の 24 時間ドーナツ。`EditableSegment` から描画し、
+/// セグメントをタップすると選択 (`selectedID`) を切り替える。
+/// - 1 周 = 24 時間、0 時を真上、時計回り。
+struct TimelineEditorDonut: View {
+    let segments: [EditableSegment]
+    let dayStart: Date
+    @Binding var selectedID: UUID?
+
+    var body: some View {
+        GeometryReader { geometry in
+            let side = min(geometry.size.width, geometry.size.height)
+            let frame = CGRect(
+                x: (geometry.size.width - side) / 2,
+                y: (geometry.size.height - side) / 2,
+                width: side,
+                height: side
+            )
+            Canvas { context, _ in
+                draw(in: &context, frame: frame)
+            }
+            .contentShape(Rectangle())
+            .onTapGesture { location in
+                selectSegment(at: location, frame: frame)
+            }
+        }
+        .aspectRatio(1, contentMode: .fit)
+    }
+
+    private func draw(in context: inout GraphicsContext, frame: CGRect) {
+        let center = CGPoint(x: frame.midX, y: frame.midY)
+        let outer = frame.width / 2
+        let inner = outer * 0.55
+
+        let ring = annularSector(center: center, innerRadius: inner, outerRadius: outer, startDeg: -90, endDeg: 270)
+        context.fill(ring, with: .color(Color.secondary.opacity(0.08)))
+
+        for segment in segments {
+            let startDeg = fraction(of: segment.start) * 360 - 90
+            let endDeg = fraction(of: segment.end) * 360 - 90
+            guard endDeg > startDeg else { continue }
+            let color = Color(hex: segment.colorHex) ?? .accentColor
+            let isSelected = segment.id == selectedID
+            let sector = annularSector(
+                center: center,
+                innerRadius: inner,
+                outerRadius: outer,
+                startDeg: startDeg,
+                endDeg: endDeg
+            )
+            context.fill(sector, with: .color(color.opacity(isSelected ? 1 : 0.6)))
+            if isSelected {
+                context.stroke(sector, with: .color(.primary), lineWidth: 2)
+            }
+        }
+    }
+
+    private func selectSegment(at location: CGPoint, frame: CGRect) {
+        let center = CGPoint(x: frame.midX, y: frame.midY)
+        let dx = location.x - center.x
+        let dy = location.y - center.y
+        let radius = Darwin.sqrt(dx * dx + dy * dy)
+        let outer = frame.width / 2
+        let inner = outer * 0.55
+        guard radius >= inner, radius <= outer else { return }
+
+        let degrees = Darwin.atan2(dy, dx) * 180 / .pi
+        var frac = (degrees + 90) / 360
+        frac = frac.truncatingRemainder(dividingBy: 1)
+        if frac < 0 { frac += 1 }
+        let tappedTime = dayStart.addingTimeInterval(frac * 86400)
+
+        let hit = segments.first { $0.start <= tappedTime && tappedTime < $0.end }
+        selectedID = (hit?.id == selectedID) ? selectedID : hit?.id
+    }
+
+    private func fraction(of date: Date) -> Double {
+        date.timeIntervalSince(dayStart) / 86400.0
+    }
+
+    private func annularSector(
+        center: CGPoint,
+        innerRadius: Double,
+        outerRadius: Double,
+        startDeg: Double,
+        endDeg: Double
+    ) -> Path {
+        var path = Path()
+        path.addArc(
+            center: center,
+            radius: outerRadius,
+            startAngle: .degrees(startDeg),
+            endAngle: .degrees(endDeg),
+            clockwise: false
+        )
+        path.addArc(
+            center: center,
+            radius: innerRadius,
+            startAngle: .degrees(endDeg),
+            endAngle: .degrees(startDeg),
+            clockwise: true
+        )
+        path.closeSubpath()
+        return path
+    }
+}

--- a/ios/DailyLogTests/ActivityOverlapResolverTests.swift
+++ b/ios/DailyLogTests/ActivityOverlapResolverTests.swift
@@ -1,0 +1,150 @@
+@testable import DailyLog
+import XCTest
+
+final class ActivityOverlapResolverTests: XCTestCase {
+    private let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "Asia/Tokyo") ?? .current
+        return calendar
+    }()
+
+    func testExtendingEndIntoNextPartiallyTrimsNextStart() {
+        let segA = segment("A", 9, 0, 10, 0)
+        let segB = segment("B", 10, 0, 12, 0)
+
+        // A の終了を 11:00 へ延長 → B は右重なりなので開始が 11:00 にトリムされる
+        let result = ActivityOverlapResolver.apply(
+            editedID: segA.id,
+            newStart: segA.start,
+            newEnd: time(11, 0),
+            to: [segA, segB]
+        )
+
+        XCTAssertTrue(result.deletedIDs.isEmpty)
+        XCTAssertEqual(result.updated.first { $0.id == segA.id }?.end, time(11, 0))
+        XCTAssertEqual(result.updated.first { $0.id == segB.id }?.start, time(11, 0))
+        XCTAssertEqual(result.updated.first { $0.id == segB.id }?.end, time(12, 0))
+    }
+
+    func testFullyCoveredSegmentIsDeleted() {
+        let segA = segment("A", 9, 0, 10, 0)
+        let segB = segment("B", 10, 30, 11, 0)
+
+        // A の終了を 12:00 へ延長 → B (10:30-11:00) は完全被覆 → 削除
+        let result = ActivityOverlapResolver.apply(
+            editedID: segA.id,
+            newStart: segA.start,
+            newEnd: time(12, 0),
+            to: [segA, segB]
+        )
+
+        XCTAssertEqual(result.deletedIDs, [segB.id])
+        XCTAssertNil(result.updated.first { $0.id == segB.id })
+    }
+
+    func testCascadeDeletesCoveredAndTrimsPartial() {
+        let segA = segment("A", 9, 0, 10, 0)
+        let segB = segment("B", 10, 0, 11, 0) // 完全被覆される
+        let segC = segment("C", 11, 0, 13, 0) // 部分的に被る
+
+        // A の終了を 12:00 まで大きく延長 → B 削除, C 開始 12:00 にトリム
+        let result = ActivityOverlapResolver.apply(
+            editedID: segA.id,
+            newStart: segA.start,
+            newEnd: time(12, 0),
+            to: [segA, segB, segC]
+        )
+
+        XCTAssertEqual(result.deletedIDs, [segB.id])
+        XCTAssertEqual(result.updated.first { $0.id == segC.id }?.start, time(12, 0))
+        XCTAssertEqual(result.updated.first { $0.id == segC.id }?.end, time(13, 0))
+    }
+
+    func testSegmentContainingEditedIsTrimmedToLeftPart() {
+        let big = segment("BIG", 8, 0, 14, 0)
+        let segX = segment("X", 10, 0, 11, 0)
+
+        // X を 9:00-12:00 に拡張 → BIG は X を内包 → 左側 (8:00-9:00) を残す
+        let result = ActivityOverlapResolver.apply(
+            editedID: segX.id,
+            newStart: time(9, 0),
+            newEnd: time(12, 0),
+            to: [big, segX]
+        )
+
+        XCTAssertTrue(result.deletedIDs.isEmpty)
+        XCTAssertEqual(result.updated.first { $0.id == big.id }?.start, time(8, 0))
+        XCTAssertEqual(result.updated.first { $0.id == big.id }?.end, time(9, 0))
+    }
+
+    func testLeftOverlapTrimsPreviousEnd() {
+        let segA = segment("A", 9, 0, 11, 0)
+        let segB = segment("B", 11, 0, 12, 0)
+
+        // B の開始を 10:00 へ前倒し → A は左重なり → A.end が 10:00 にトリム
+        let result = ActivityOverlapResolver.apply(
+            editedID: segB.id,
+            newStart: time(10, 0),
+            newEnd: segB.end,
+            to: [segA, segB]
+        )
+
+        XCTAssertTrue(result.deletedIDs.isEmpty)
+        XCTAssertEqual(result.updated.first { $0.id == segA.id }?.end, time(10, 0))
+        XCTAssertEqual(result.updated.first { $0.id == segB.id }?.start, time(10, 0))
+    }
+
+    func testNonOverlappingSegmentsUnchanged() {
+        let segA = segment("A", 9, 0, 10, 0)
+        let segB = segment("B", 12, 0, 13, 0)
+
+        // A を 9:30 までに短縮 → B とは無関係
+        let result = ActivityOverlapResolver.apply(
+            editedID: segA.id,
+            newStart: segA.start,
+            newEnd: time(9, 30),
+            to: [segA, segB]
+        )
+
+        XCTAssertTrue(result.deletedIDs.isEmpty)
+        XCTAssertEqual(result.updated.first { $0.id == segB.id }, segB)
+    }
+
+    func testOrderIsPreserved() {
+        let segA = segment("A", 9, 0, 10, 0)
+        let segB = segment("B", 10, 0, 11, 0)
+        let segC = segment("C", 11, 0, 12, 0)
+
+        let result = ActivityOverlapResolver.apply(
+            editedID: segB.id,
+            newStart: segB.start,
+            newEnd: segB.end,
+            to: [segA, segB, segC]
+        )
+
+        XCTAssertEqual(result.updated.map(\.id), [segA.id, segB.id, segC.id])
+    }
+
+    // MARK: - Helpers
+
+    private func time(_ hour: Int, _ minute: Int) -> Date {
+        let components = DateComponents(year: 2026, month: 4, day: 25, hour: hour, minute: minute)
+        return calendar.date(from: components) ?? Date()
+    }
+
+    private func segment(
+        _ name: String,
+        _ startHour: Int,
+        _ startMinute: Int,
+        _ endHour: Int,
+        _ endMinute: Int
+    ) -> EditableSegment {
+        EditableSegment(
+            id: UUID(),
+            start: time(startHour, startMinute),
+            end: time(endHour, endMinute),
+            templateName: name,
+            colorHex: "#333333"
+        )
+    }
+}


### PR DESCRIPTION
## 概要
その日のアクション記録のミスを手動で修正できるようにする。統計改善シリーズの PR5 (最終)。

## 変更点
- 日別詳細 (`DayDetailView`) に「修正」ボタンを追加し編集画面 `DayEditView` を sheet で開く
- **編集 UI**
  - 上: 時系列ドーナツ (プレビュー、タップでセグメント選択)
  - 下: 時系列順の記録リスト。各記録の開始/終了時刻を **±5分・±15分ボタン**で調整 (入力欄なし)
- **重複の自動解決 (上書き = トリム + 完全被覆は削除)** — `ActivityOverlapResolver` (純ロジック)
  - 完全被覆された記録は削除候補、部分的に被った記録は開始/終了をトリム
  - 終了を大きく後ろにずらして後続複数に被るカスケードでも、被覆分は削除・部分重なりはトリムで解消し、後続が黙って潰れない
  - 削除が発生する場合は**保存前に確認ダイアログ**で一覧提示
- 安全のため**当日内で完結する完了済み記録のみ**を編集対象とする (日跨ぎ/進行中は対象外。除外があればその旨を表示)

## カスケード問題への解 (ご質問への回答)
「終了時刻を大きく後ろにして後続2つに被る」場合、単純なスナップだと最初の後続が潰れます。本 PR は**上書きモデル**を採用し、潰れる(=完全に覆われる)記録は確認の上で削除、部分的に被る記録はトリムすることで破綻を回避します。

## テスト
- `ActivityOverlapResolver` の単体テスト 7 件 (被覆削除 / 左右トリム / 多段カスケード / 内包トリム / 非重複維持 / 順序保持)
- ローカルで `xcodebuild test` 全102テスト green
- UI (DayEditView / ドーナツ) はビルド検証済み。実機/シミュレータでの手動確認を推奨

## 既知の制約 / フォローアップ候補
- ドーナツは現状プレビュー + タップ選択まで。**境界ドラッグでの時刻調整は未実装** (±ボタンで代替)。必要なら follow-up で追加します。
- 深夜跨ぎアクションの分割編集は対象外。

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)