### PR TITLE
feat: 修正画面のドーナツ境界ドラッグで時刻調整

### DIFF
--- a/ios/DailyLog/Views/Calendar/DayEditView.swift
+++ b/ios/DailyLog/Views/Calendar/DayEditView.swift
@@ -21,6 +21,9 @@ struct DayEditView: View {
     @State private var excludedCount = 0
     @State private var showDeleteConfirm = false
     @State private var didPopulate = false
+    /// ドラッグ開始時のレイアウト (ドラッグ中はここを基準に毎回再解決する)。
+    @State private var dragBaseline: [EditableSegment]?
+    @State private var dragDeletedIDs: [UUID] = []
 
     private let calendar: Calendar = .currentGregorian
     private let now: Date = .init()
@@ -33,8 +36,15 @@ struct DayEditView: View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 16) {
-                    TimelineEditorDonut(segments: segments, dayStart: dayStart, selectedID: $selectedID)
-                        .frame(height: 220)
+                    TimelineEditorDonut(
+                        segments: segments,
+                        dayStart: dayStart,
+                        selectedID: $selectedID,
+                        onBeginDrag: beginDrag,
+                        onDragBoundary: dragBoundary,
+                        onEndDrag: endDrag
+                    )
+                    .frame(height: 220)
 
                     if excludedCount > 0 {
                         Text("日をまたぐ / 進行中の記録は修正対象外です")
@@ -111,6 +121,38 @@ struct DayEditView: View {
 
     private func clamp(_ date: Date, lower: Date, upper: Date) -> Date {
         min(max(date, lower), upper)
+    }
+
+    // MARK: - ドーナツ境界ドラッグ
+
+    private func beginDrag() {
+        dragBaseline = segments
+        dragDeletedIDs = []
+    }
+
+    private func dragBoundary(_ id: UUID, isStart: Bool, newTime: Date) {
+        guard let baseline = dragBaseline, let current = baseline.first(where: { $0.id == id }) else { return }
+        let dayEnd = dayStart.addingTimeInterval(86400)
+        let clamped = clamp(newTime, lower: dayStart, upper: dayEnd)
+        let newStart = isStart ? clamped : current.start
+        let newEnd = isStart ? current.end : clamped
+        guard newEnd.timeIntervalSince(newStart) >= 60 else { return }
+
+        let result = ActivityOverlapResolver.apply(editedID: id, newStart: newStart, newEnd: newEnd, to: baseline)
+        dragDeletedIDs = result.deletedIDs
+        selectedID = id
+        segments = result.updated
+    }
+
+    private func endDrag() {
+        guard let baseline = dragBaseline else { return }
+        for deletedID in dragDeletedIDs {
+            if let deleted = baseline.first(where: { $0.id == deletedID }) {
+                pendingDeleted.append(deleted)
+            }
+        }
+        dragBaseline = nil
+        dragDeletedIDs = []
     }
 
     // MARK: - Persistence

--- a/ios/DailyLog/Views/Calendar/TimelineEditorDonut.swift
+++ b/ios/DailyLog/Views/Calendar/TimelineEditorDonut.swift
@@ -8,6 +8,20 @@ struct TimelineEditorDonut: View {
     let segments: [EditableSegment]
     let dayStart: Date
     @Binding var selectedID: UUID?
+    /// ドラッグ開始時に呼ばれる (呼び出し側で基準レイアウトを退避)。
+    var onBeginDrag: () -> Void = {}
+    /// ドラッグ中、(セグメントID, 開始境界か, 新しい時刻) を通知。
+    var onDragBoundary: (UUID, Bool, Date) -> Void = { _, _, _ in }
+    /// ドラッグ確定時に呼ばれる。
+    var onEndDrag: () -> Void = {}
+
+    /// ドラッグ中に掴んでいる境界。
+    @State private var grab: Grab?
+
+    private struct Grab {
+        let id: UUID
+        let isStart: Bool
+    }
 
     var body: some View {
         GeometryReader { geometry in
@@ -25,8 +39,35 @@ struct TimelineEditorDonut: View {
             .onTapGesture { location in
                 selectSegment(at: location, frame: frame)
             }
+            .gesture(dragGesture(frame: frame))
         }
         .aspectRatio(1, contentMode: .fit)
+    }
+
+    private func dragGesture(frame: CGRect) -> some Gesture {
+        DragGesture(minimumDistance: 8, coordinateSpace: .local)
+            .onChanged { value in handleDrag(value, frame: frame) }
+            .onEnded { _ in
+                if grab != nil { onEndDrag() }
+                grab = nil
+            }
+    }
+
+    private func handleDrag(_ value: DragGesture.Value, frame: CGRect) {
+        if grab == nil {
+            // ドラッグ開始位置から掴む境界を決定する。
+            guard inRing(value.startLocation, frame: frame) else { return }
+            let startTime = angleTime(at: value.startLocation, frame: frame)
+            guard let segment = segmentContaining(startTime) ?? selectedSegment else { return }
+            let isStart = abs(startTime.timeIntervalSince(segment.start))
+                <= abs(segment.end.timeIntervalSince(startTime))
+            grab = Grab(id: segment.id, isStart: isStart)
+            selectedID = segment.id
+            onBeginDrag()
+        }
+        guard let grab else { return }
+        let time = snap(angleTime(at: value.location, frame: frame))
+        onDragBoundary(grab.id, grab.isStart, time)
     }
 
     private func draw(in context: inout GraphicsContext, frame: CGRect) {
@@ -58,22 +99,45 @@ struct TimelineEditorDonut: View {
     }
 
     private func selectSegment(at location: CGPoint, frame: CGRect) {
-        let center = CGPoint(x: frame.midX, y: frame.midY)
-        let dx = location.x - center.x
-        let dy = location.y - center.y
+        guard inRing(location, frame: frame) else { return }
+        let tappedTime = angleTime(at: location, frame: frame)
+        if let hit = segmentContaining(tappedTime) {
+            selectedID = hit.id
+        }
+    }
+
+    private func segmentContaining(_ time: Date) -> EditableSegment? {
+        segments.first { $0.start <= time && time < $0.end }
+    }
+
+    private var selectedSegment: EditableSegment? {
+        segments.first { $0.id == selectedID }
+    }
+
+    private func inRing(_ location: CGPoint, frame: CGRect) -> Bool {
+        let dx = location.x - frame.midX
+        let dy = location.y - frame.midY
         let radius = Darwin.sqrt(dx * dx + dy * dy)
         let outer = frame.width / 2
-        let inner = outer * 0.55
-        guard radius >= inner, radius <= outer else { return }
+        return radius >= outer * 0.55 && radius <= outer
+    }
 
+    /// タッチ位置の角度から当日内の時刻を求める (0 時を真上、時計回り)。
+    private func angleTime(at location: CGPoint, frame: CGRect) -> Date {
+        let dx = location.x - frame.midX
+        let dy = location.y - frame.midY
         let degrees = Darwin.atan2(dy, dx) * 180 / .pi
         var frac = (degrees + 90) / 360
         frac = frac.truncatingRemainder(dividingBy: 1)
         if frac < 0 { frac += 1 }
-        let tappedTime = dayStart.addingTimeInterval(frac * 86400)
+        return dayStart.addingTimeInterval(frac * 86400)
+    }
 
-        let hit = segments.first { $0.start <= tappedTime && tappedTime < $0.end }
-        selectedID = (hit?.id == selectedID) ? selectedID : hit?.id
+    /// 5 分単位にスナップする。
+    private func snap(_ date: Date) -> Date {
+        let step: TimeInterval = 5 * 60
+        let snapped = (date.timeIntervalSince(dayStart) / step).rounded() * step
+        return dayStart.addingTimeInterval(snapped)
     }
 
     private func fraction(of date: Date) -> Double {


### PR DESCRIPTION
## 概要
PR #86 の follow-up。修正画面の時系列ドーナツで、セグメント境界をドラッグして開始/終了時刻を直接調整できるようにする。

## 変更点
- ドーナツのセグメント境界(開始/終了)を掴んで**ドラッグ → 時刻を調整**(5分スナップ)
  - ドラッグ開始位置から近い方の境界を掴む
  - **タップは従来どおり選択のみ**(境界を動かさない。DragGesture の minimumDistance で分離)
- ドラッグ中は**ドラッグ開始時のレイアウトを基準に毎回 `ActivityOverlapResolver` で再解決**
  - 往復しても他の記録が不可逆に潰れない(基準から再計算するため)
- ドラッグ確定時に削除分を `pendingDeleted` へ反映し、保存時に確認ダイアログ

## テスト
- 既存の `ActivityOverlapResolver` 単体テストがドラッグ経路の解決ロジックを担保
- ローカルで `xcodebuild test` 全102テスト green
- ドラッグ操作自体はビルド検証 + 手動確認推奨

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)