### PR TITLE
feat: 音声メモのマイクを「今日のメモ」へ移動し記録中カードから撤去

### DIFF
--- a/ios/DailyLog/Views/DailyMemoCard.swift
+++ b/ios/DailyLog/Views/DailyMemoCard.swift
@@ -10,6 +10,7 @@ struct DailyMemoCard: View {
 
     @State private var draft: String = ""
     @State private var loadedDayKey: String?
+    @State private var isPresentingVoiceMemo = false
     @FocusState private var isFocused: Bool
 
     private let calendar: Calendar = .currentGregorian
@@ -24,7 +25,7 @@ struct DailyMemoCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack {
+            HStack(spacing: 12) {
                 Label("今日のメモ", systemImage: "note.text")
                     .font(.subheadline.bold())
                     .foregroundStyle(.secondary)
@@ -35,6 +36,13 @@ struct DailyMemoCard: View {
                     }
                     .font(.caption)
                 }
+                Button {
+                    isPresentingVoiceMemo = true
+                } label: {
+                    Image(systemName: "mic")
+                        .font(.subheadline)
+                }
+                .accessibilityLabel("音声メモ")
             }
 
             ZStack(alignment: .topLeading) {
@@ -61,6 +69,16 @@ struct DailyMemoCard: View {
         .onChange(of: draft) { _, newValue in
             save(text: newValue)
         }
+        .sheet(isPresented: $isPresentingVoiceMemo) {
+            VoiceMemoSheet(onAppend: appendTranscription)
+        }
+    }
+
+    /// 音声認識テキストを今日のメモ末尾へ追記する。空文字列は無視。
+    private func appendTranscription(_ text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        draft = draft.isEmpty ? trimmed : draft + "\n" + trimmed
     }
 
     private func loadIfNeeded() {

--- a/ios/DailyLog/Views/InProgressCard.swift
+++ b/ios/DailyLog/Views/InProgressCard.swift
@@ -5,7 +5,6 @@ struct InProgressCard: View {
     let onStop: () -> Void
 
     @State private var now: Date = .init()
-    @State private var isPresentingVoiceMemo = false
     @State private var isPresentingMeal = false
 
     private let timer = Timer
@@ -27,11 +26,6 @@ struct InProgressCard: View {
                 .fill(Color(.secondarySystemBackground))
         )
         .onReceive(timer) { now = $0 }
-        .sheet(isPresented: $isPresentingVoiceMemo) {
-            if let activity {
-                VoiceMemoSheet(activity: activity)
-            }
-        }
         .sheet(isPresented: $isPresentingMeal) {
             if let activity {
                 MealDetailView(activity: activity)
@@ -61,8 +55,6 @@ struct InProgressCard: View {
                 mealButton
             }
 
-            micButton
-
             stopButton
         }
     }
@@ -77,18 +69,6 @@ struct InProgressCard: View {
         }
         .buttonStyle(.bordered)
         .accessibilityLabel("食事の記録")
-    }
-
-    private var micButton: some View {
-        Button {
-            isPresentingVoiceMemo = true
-        } label: {
-            Image(systemName: "mic")
-                .font(.title3)
-                .frame(width: 44, height: 44)
-        }
-        .buttonStyle(.bordered)
-        .accessibilityLabel("音声メモ")
     }
 
     private var stopButton: some View {

--- a/ios/DailyLog/Views/VoiceMemoSheet.swift
+++ b/ios/DailyLog/Views/VoiceMemoSheet.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
 struct VoiceMemoSheet: View {
-    let activity: Activity
+    /// 認識テキストの追記先 (呼び出し側でメモへ追記する)。
+    let onAppend: (String) -> Void
 
     @Environment(\.dismiss) private var dismiss
     @StateObject private var recognizer = SpeechRecognitionService()
@@ -150,8 +151,7 @@ struct VoiceMemoSheet: View {
 
     private func save() {
         recognizer.stopRecording()
-        activity.appendNote(recognizer.transcription)
-        try? activity.modelContext?.save()
+        onAppend(recognizer.transcription)
         dismiss()
     }
 }


### PR DESCRIPTION
## 概要
マイク(音声メモ)ボタンを行動記録中カード(InProgressCard)から「今日のメモ」(DailyMemoCard)へ移動する。

## 変更点
- **InProgressCard**: マイクボタンと音声メモシート提示を廃止(残るのは 食事ボタン[meal時]＋停止ボタン)
- **DailyMemoCard**: ヘッダにマイクボタンを追加。音声認識テキストを**今日のメモ末尾へ追記**(空は無視、既存があれば改行区切り)。追記で `draft` が変わり既存の自動保存が走る
- **VoiceMemoSheet**: `activity` 固定をやめ、追記先を `onAppend: (String) -> Void` クロージャで受け取る汎用シートに変更

## テスト
- ローカルで `build-for-testing` 成功(コンパイル確認)
- ※ ローカルのシミュレータが別作業の `simctl erase` 起因で起動拒否状態のため、全テスト実行は CI に委ねます

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)