### PR TITLE
feat: 日別詳細の記録リストをタップして開始/終了時刻の変更・削除

### DIFF
--- a/ios/DailyLog/Views/Calendar/ActivityEditSheet.swift
+++ b/ios/DailyLog/Views/Calendar/ActivityEditSheet.swift
@@ -1,0 +1,107 @@
+import SwiftData
+import SwiftUI
+
+/// 記録 1 件の開始/終了時刻を変更・削除するシート。
+/// 時刻は当日内かつ前後の記録と重ならない範囲に制限する
+/// (大きな移動や重ね合わせは「修正」エディタを使う)。
+struct ActivityEditSheet: View {
+    let activity: Activity
+    /// 同じ日の記録 (前後の境界算出用)。
+    let dayActivities: [Activity]
+    var calendar: Calendar = .currentGregorian
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+
+    @State private var start: Date
+    @State private var end: Date
+    @State private var showDeleteConfirm = false
+
+    init(activity: Activity, dayActivities: [Activity], calendar: Calendar = .currentGregorian) {
+        self.activity = activity
+        self.dayActivities = dayActivities
+        self.calendar = calendar
+        _start = State(initialValue: activity.startAt)
+        _end = State(initialValue: activity.endAt ?? Date())
+    }
+
+    private var dayStart: Date {
+        calendar.startOfDay(for: activity.startAt)
+    }
+
+    private var dayEnd: Date {
+        dayStart.addingTimeInterval(86400)
+    }
+
+    /// 前の記録の終了 (これより前には開始できない)。
+    private var lowerBound: Date {
+        let others = dayActivities.filter { $0.id != activity.id && $0.startAt < activity.startAt }
+        return others.compactMap(\.endAt).max() ?? dayStart
+    }
+
+    /// 次の記録の開始 (これより後には終了できない)。
+    private var upperBound: Date {
+        let others = dayActivities.filter { $0.id != activity.id && $0.startAt > activity.startAt }
+        return others.map(\.startAt).min() ?? dayEnd
+    }
+
+    /// DatePicker 用の選択可能範囲。境界が逆転/退化している場合は当日全体にフォールバック。
+    private var selectableRange: ClosedRange<Date> {
+        upperBound > lowerBound ? lowerBound ... upperBound : dayStart ... dayEnd
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    LabeledContent("アクション", value: activity.template?.name ?? "（未分類）")
+                }
+
+                Section("時刻") {
+                    DatePicker("開始", selection: $start, in: selectableRange, displayedComponents: .hourAndMinute)
+                    DatePicker("終了", selection: $end, in: selectableRange, displayedComponents: .hourAndMinute)
+                    if end <= start {
+                        Text("終了は開始より後にしてください")
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                Section {
+                    Button("この記録を削除", role: .destructive) {
+                        showDeleteConfirm = true
+                    }
+                }
+            }
+            .navigationTitle("記録を編集")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("キャンセル") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("保存") { save() }
+                        .disabled(end <= start)
+                }
+            }
+            .confirmationDialog("この記録を削除しますか？", isPresented: $showDeleteConfirm, titleVisibility: .visible) {
+                Button("削除", role: .destructive) { deleteActivity() }
+                Button("キャンセル", role: .cancel) {}
+            }
+        }
+    }
+
+    private func save() {
+        guard end > start else { return }
+        activity.startAt = start
+        activity.endAt = end
+        try? modelContext.save()
+        dismiss()
+    }
+
+    private func deleteActivity() {
+        modelContext.delete(activity)
+        try? modelContext.save()
+        dismiss()
+    }
+}

--- a/ios/DailyLog/Views/Calendar/DayDetailView.swift
+++ b/ios/DailyLog/Views/Calendar/DayDetailView.swift
@@ -11,6 +11,7 @@ struct DayDetailView: View {
 
     @State private var chartMode: ChartMode = .timeline
     @State private var isEditing = false
+    @State private var editingActivity: Activity?
 
     private let calendar: Calendar = .currentGregorian
 
@@ -101,7 +102,12 @@ struct DayDetailView: View {
                         .foregroundStyle(.secondary)
                 } else {
                     ForEach(activities) { activity in
-                        DayActivityRow(activity: activity)
+                        Button {
+                            editingActivity = activity
+                        } label: {
+                            DayActivityRow(activity: activity)
+                        }
+                        .buttonStyle(.plain)
                     }
                 }
             }
@@ -116,6 +122,9 @@ struct DayDetailView: View {
         }
         .sheet(isPresented: $isEditing) {
             DayEditView(date: date)
+        }
+        .sheet(item: $editingActivity) { activity in
+            ActivityEditSheet(activity: activity, dayActivities: activities, calendar: calendar)
         }
     }
 


### PR DESCRIPTION
## 概要
日別詳細の「記録」リストのアイテムをタップして、その記録の開始/終了時刻を変更したり、記録を削除したりできるようにする。

## 変更点
- 記録の行を**タップで編集シート `ActivityEditSheet`** を表示
- 開始/終了時刻を **DatePicker** で変更
  - **前後の記録と重ならない範囲**(前の記録の終了〜次の記録の開始)に制限。境界が退化/逆転している場合は当日全体にフォールバック
  - 終了が開始以前なら保存を無効化
- その記録を**確認ダイアログ付きで削除**
- 大きな移動や重ね合わせ(上書き)は既存の「修正」エディタが担当する分担

## テスト
- ローカルで `build-for-testing` 成功(コンパイル確認)
- ※ ローカルのシミュレータが起動不可のため全テストは CI に委任
- 操作感は実機での確認を推奨

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)