### PR TITLE
feat: 記録編集でアクションを変更可能にしアイコン表示を追加

### DIFF
--- a/ios/DailyLog/Views/Calendar/ActivityEditSheet.swift
+++ b/ios/DailyLog/Views/Calendar/ActivityEditSheet.swift
@@ -1,7 +1,7 @@
 import SwiftData
 import SwiftUI
 
-/// 記録 1 件の開始/終了時刻を変更・削除するシート。
+/// 記録 1 件のアクション・開始/終了時刻を変更・削除するシート。
 /// 時刻は当日内かつ前後の記録と重ならない範囲に制限する
 /// (大きな移動や重ね合わせは「修正」エディタを使う)。
 struct ActivityEditSheet: View {
@@ -10,9 +10,16 @@ struct ActivityEditSheet: View {
     let dayActivities: [Activity]
     var calendar: Calendar = .currentGregorian
 
+    @Query(
+        filter: #Predicate<ActivityTemplate> { !$0.isHidden },
+        sort: \ActivityTemplate.sortOrder
+    )
+    private var templates: [ActivityTemplate]
+
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
 
+    @State private var selectedTemplateID: UUID?
     @State private var start: Date
     @State private var end: Date
     @State private var showDeleteConfirm = false
@@ -21,8 +28,13 @@ struct ActivityEditSheet: View {
         self.activity = activity
         self.dayActivities = dayActivities
         self.calendar = calendar
+        _selectedTemplateID = State(initialValue: activity.template?.id)
         _start = State(initialValue: activity.startAt)
         _end = State(initialValue: activity.endAt ?? Date())
+    }
+
+    private var selectedTemplate: ActivityTemplate? {
+        templates.first { $0.id == selectedTemplateID } ?? activity.template
     }
 
     private var dayStart: Date {
@@ -53,37 +65,14 @@ struct ActivityEditSheet: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section {
-                    LabeledContent("アクション", value: activity.template?.name ?? "（未分類）")
-                }
-
-                Section("時刻") {
-                    DatePicker("開始", selection: $start, in: selectableRange, displayedComponents: .hourAndMinute)
-                    DatePicker("終了", selection: $end, in: selectableRange, displayedComponents: .hourAndMinute)
-                    if end <= start {
-                        Text("終了は開始より後にしてください")
-                            .font(.caption)
-                            .foregroundStyle(.red)
-                    }
-                }
-
-                Section {
-                    Button("この記録を削除", role: .destructive) {
-                        showDeleteConfirm = true
-                    }
-                }
+                headerSection
+                actionSection
+                timeSection
+                deleteSection
             }
             .navigationTitle("記録を編集")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("キャンセル") { dismiss() }
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("保存") { save() }
-                        .disabled(end <= start)
-                }
-            }
+            .toolbar { toolbarContent }
             .confirmationDialog("この記録を削除しますか？", isPresented: $showDeleteConfirm, titleVisibility: .visible) {
                 Button("削除", role: .destructive) { deleteActivity() }
                 Button("キャンセル", role: .cancel) {}
@@ -91,8 +80,83 @@ struct ActivityEditSheet: View {
         }
     }
 
+    private var headerSection: some View {
+        Section {
+            HStack(spacing: 12) {
+                actionIcon(for: selectedTemplate, size: 40)
+                Text(selectedTemplate?.name ?? "（未分類）")
+                    .font(.headline)
+                Spacer()
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    private var actionSection: some View {
+        Section("アクション") {
+            Picker("アクション", selection: $selectedTemplateID) {
+                ForEach(templates) { template in
+                    actionRow(for: template).tag(Optional(template.id))
+                }
+            }
+            .pickerStyle(.navigationLink)
+        }
+    }
+
+    private var timeSection: some View {
+        Section("時刻") {
+            DatePicker("開始", selection: $start, in: selectableRange, displayedComponents: .hourAndMinute)
+            DatePicker("終了", selection: $end, in: selectableRange, displayedComponents: .hourAndMinute)
+            if end <= start {
+                Text("終了は開始より後にしてください")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private var deleteSection: some View {
+        Section {
+            Button("この記録を削除", role: .destructive) {
+                showDeleteConfirm = true
+            }
+        }
+    }
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        ToolbarItem(placement: .cancellationAction) {
+            Button("キャンセル") { dismiss() }
+        }
+        ToolbarItem(placement: .confirmationAction) {
+            Button("保存") { save() }
+                .disabled(end <= start)
+        }
+    }
+
+    private func actionRow(for template: ActivityTemplate) -> some View {
+        HStack(spacing: 10) {
+            actionIcon(for: template, size: 28)
+            Text(template.name)
+        }
+    }
+
+    private func actionIcon(for template: ActivityTemplate?, size: CGFloat) -> some View {
+        Image(systemName: template?.iconName ?? "circle")
+            .font(size >= 36 ? .title3 : .callout)
+            .foregroundStyle(.white)
+            .frame(width: size, height: size)
+            .background(
+                Circle()
+                    .fill(template.flatMap { Color(hex: $0.colorHex) } ?? Color.secondary)
+            )
+    }
+
     private func save() {
         guard end > start else { return }
+        if let template = templates.first(where: { $0.id == selectedTemplateID }) {
+            activity.template = template
+        }
         activity.startAt = start
         activity.endAt = end
         try? modelContext.save()


### PR DESCRIPTION
## 概要
記録を編集する画面(ActivityEditSheet)で、開始/終了時刻に加えて**アクション自体も変更**できるようにし、アクションが分かりやすいよう**アイコン+色**を表示する。

## 変更点
- 編集シート上部に現在のアクションを**アイコン(色付き丸)+名前**で大きく表示
- **アクション選択ピッカー**(navigationLink)を追加し、別のアクション(テンプレート)へ変更可能
  - ピッカーの各行もアイコン+名前で表示
  - 保存時に `activity.template` を更新
- 候補は非表示でないテンプレートを `sortOrder` 順に列挙(ホームのグリッドと同基準)

## テスト
- ローカルで `build-for-testing` 成功(コンパイル確認)
- ※ ローカルのシミュレータが起動不可のため全テストは CI に委任
- 操作感・見た目は実機での確認を推奨

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)