### PR TITLE
fix: 記録行の中央空白をタップしても編集に飛ばない問題を修正

### DIFF
--- a/ios/DailyLog/Views/Calendar/DayDetailView.swift
+++ b/ios/DailyLog/Views/Calendar/DayDetailView.swift
@@ -106,6 +106,7 @@ struct DayDetailView: View {
                             editingActivity = activity
                         } label: {
                             DayActivityRow(activity: activity)
+                                .contentShape(Rectangle())
                         }
                         .buttonStyle(.plain)
                     }


### PR DESCRIPTION
## 現象
記録リストの行で、テキスト/時間のある部分はタップで編集シートに飛ぶが、中央の空白(Spacer 部分)をタップしても反応しない。

## 原因
行 (DayActivityRow) 中央が Spacer による空白で、Button のタップ当たり判定が中身のある領域に限られていた。

## 修正
行コンテンツに `.contentShape(Rectangle())` を付与し、行全体を当たり判定にした。

## テスト
- ローカルで `build-for-testing` 成功
- ※ シミュレータ起動不可のため全テストは CI に委任。操作は実機確認推奨

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)